### PR TITLE
Fix role and trust relationship policy

### DIFF
--- a/aws-cloud-integrations.md
+++ b/aws-cloud-integrations.md
@@ -204,7 +204,7 @@ On each sub account running kubecost, attach both of the following policies to t
                ]
 	}
 ```
-On the masterpayer account, attach this policy to a role:
+On the masterpayer account, attach this policy to a role (replace `${AthenaCURBucket}` variable):
 ```
 	{
                "Version": "2012-10-17",
@@ -239,14 +239,14 @@ On the masterpayer account, attach this policy to a role:
                      "Sid": "AthenaQueryResultsOutput",
                      "Effect": "Allow",
                      "Action": [
-                        "s3:GetBucketLocation"
+                        "s3:GetBucketLocation",
                         "s3:GetObject",
                         "s3:ListBucket",
                         "s3:ListBucketMultipartUploads",
                         "s3:ListMultipartUploadParts",
                         "s3:AbortMultipartUpload",
                         "s3:CreateBucket",
-                        "s3:PutObject,
+                        "s3:PutObject"
                      ],
                      "Resource": [
                         "arn:aws:s3:::aws-athena-query-results-*"
@@ -266,7 +266,7 @@ On the masterpayer account, attach this policy to a role:
                ]
 	}
 ```
-You will then need to add the following trust statement to the role the policy is attached to:
+You will then need to add the following trust statement to the role the policy is attached to (replace `${KubecostClusterID}` variable):
 ```
 	{
                "Version": "2012-10-17",
@@ -274,7 +274,7 @@ You will then need to add the following trust statement to the role the policy i
                   {
                      "Effect": "Allow",
                      "Principal": {
-                        "AWS": `'arn:aws:iam::${KubecostClusterID}:root'`
+                        "AWS": "arn:aws:iam::${KubecostClusterID}:root"
                      },
                      "Action": [
                         "sts:AssumeRole"


### PR DESCRIPTION
Side note: The CFN templated provided [here](https://raw.githubusercontent.com/kubecost/cloudformation/master/kubecost-sub-account-permissions.yaml) doesn't work for us.

It failed and returned:

```
The specified value for roleName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_- (Service: AmazonIdentityManagement; Status Code: 400; Error Code: ValidationError; Request ID: 5a7f79d8-b788-432e-bdb9-e2a776e48312; Proxy: null)
```