### PR TITLE
clarify settings are related to athena

### DIFF
--- a/aws-cloud-integrations.md
+++ b/aws-cloud-integrations.md
@@ -376,9 +376,9 @@ These values can either be set from the kubecost frontend or via .Values.kubecos
     * The name of the bucket should match `s3://aws-athena-query-results-*`, so the IAM roles defined above will automatically allow access to it
     * The bucket can have a Canned ACL of `Private` or other permissions as you see fit.
 * `athenaRegion` The aws region athena is running in
-* `athenaDatabase` the name of the database created by the CUR setup
-    * The athena database name is available as the value (physical id) of `AWSCURDatabase` in the CloudFormation stack created above (in [Step 2: Setting up the CUR](#Step-2:-Setting-up-Athena))
-* `athenaTable` the name of the table created by the CUR setup
+* `athenaDatabase` the name of the database created by the Athena setup
+    * The athena database name is available as the value (physical id) of `AWSCURDatabase` in the CloudFormation stack created above (in [Step 2: Setting up Athena](#Step-2:-Setting-up-Athena))
+* `athenaTable` the name of the table created by the Athena setup
   * The table name is typically the database name with the leading `athenacurcfn_` removed (but is not available as a CloudFormation stack resource)
 
 > Make sure using only underscore as an delimiter if needed for tables and views, using dash will not work even though you might be able to create it see [docs](https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html).


### PR DESCRIPTION
Clarify that aws integration settings are related to Athena, as opposed to the CUR that sits behind Athena.

(in response to https://github.com/kubecost/docs/issues/91)