### PR TITLE
Include `namespace` in ALB example

### DIFF
--- a/ingress-examples.md
+++ b/ingress-examples.md
@@ -74,6 +74,7 @@ Once an AWS Load Balancer Controller is installed, you can use a the following I
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: kubecost # replace if kubecost is installed under another namespace
   name: kubecost-alb-ingress
   annotations:  
     kubernetes.io/ingress.class: alb


### PR DESCRIPTION
If the namespace is not specified, the load balancer may not be able to access the service