### PR TITLE
Add description of cloud process config variables

### DIFF
--- a/cloud-integration.md
+++ b/cloud-integration.md
@@ -1,13 +1,22 @@
 # Cloud Integrations
 
-Integration with the Cloud Service Providers via their respective billing APIs allow Kubecost to display Out-of-Cluster costs, which are the costs incurred on a billing account from Services Outside of the cluster(s) where Kubecost is installed, in addition to the ability to reconcile Kubecosts in-cluster predictions with actual billing data to improve accuracy. For more details on these integrations continue reading below. For guides on how to set up these integrations follow the relevant link:
+Integration with the Cloud Service Providers via their respective billing APIs allow Kubecost to display out-of-cluster costs, which are the costs incurred on a billing account from Services Outside of the cluster(s) where Kubecost is installed, in addition to the ability to reconcile Kubecosts in-cluster predictions with actual billing data to improve accuracy. For more details on these integrations continue reading below. For guides on how to set up these integrations follow the relevant link:
 - [Multi-Cloud](https://github.com/kubecost/docs/blob/master/multi-cloud.md)
 - [AWS](https://github.com/kubecost/docs/blob/master/aws-cloud-integrations.md)
 - [GCP](https://cloud.google.com/billing/docs/how-to/export-data-bigquery)
 - [Azure](https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-export-acm-data?tabs=azure-portal) 
 
+## Cloud Processes
+As indicated above, setting up a cloud integration with your Cloud Service Provider allows Kubecost to pull in additional billing data. The two processes that incorporate this information are Reconciliation and Cloud Assets.
+
+### Reconciliation
+Reconciliation matches in-cluster Assets with items found in the billing data pulled from the Cloud Service Provider. This allows kubecost to display the most accurate depiction of your in-cluster spend. Additionally, the reconciliation process creates `Network` assets for in-cluster nodes based on the information in the billing data. The main drawback of this process is that the Cloud Service Providers have between a 6 to 24 hour delay in releasing billing data, and reconciliation requires a complete day of cost data to reconcile with the in-cluster assets. This requires a 48 hour window between the resource usage and reconciliation. If reconciliation is performed within this window, asset cost is deflated to the partially complete cost shown in the billing data.
+
+### Cloud Assets
+The Cloud Assets process allows Kubecost to pull in out-of-cluster cloud spend from your Cloud Service Provider's billing data. This includes any services run by the Cloud Service Provider in addition to compute resources outside of clusters monitored by Kubecost. Additionally, by labeling these Cloud Assets their cost can be distributed to Allocations as external costs. This can help teams get a better understanding of the proportion of out-of-cluster cloud spend that their in-cluster usage is dependant on. Cloud Assets become available as soon as they appear in the billing data, with the 6 to 24 hour delay mentioned above, and are updated as they become more complete.
+
 ## Cloud Integration Configurations
-The Kubecost helm chart provides values which can enable or disable each cloud process on the deployment once a cloud integration has been set up.
+The Kubecost helm chart provides values which can enable or disable each cloud process on the deployment once a cloud integration has been set up. Turning off either of these processes will disable all the benefits provided by them.
 
 Value | Default | Description
 --: | :--: | :--


### PR DESCRIPTION
Pretty straight forward description of the helm values which were already present. I tested these on my AWS cluster by toggling values and helm upgrading followed by asset etl rebuilds
Cloud Assets Disabled:
![Screen Shot 2021-10-25 at 2 04 36 PM](https://user-images.githubusercontent.com/12225425/138770770-8805ddc5-c00f-49f6-8385-d1ec082a16a4.png)

![Screen Shot 2021-10-25 at 2 04 56 PM](https://user-images.githubusercontent.com/12225425/138770773-6612c4de-267f-4c4e-bc63-9f7bc932d912.png)
Reconciliation Disabled:
![Screen Shot 2021-10-25 at 1 56 07 PM](https://user-images.githubusercontent.com/12225425/138770826-b1877252-7f9c-4ed3-a69d-32775b45ef42.png)
![Screen Shot 2021-10-25 at 1 55 51 PM](https://user-images.githubusercontent.com/12225425/138770827-0f20daae-e4a6-4140-9951-04a4fee1d274.png)



