### PR TITLE
Document CSV download for Allocation and Assets APIs

### DIFF
--- a/allocation.md
+++ b/allocation.md
@@ -177,6 +177,7 @@ filterPods | | Comma-separated list of pods to match; e.g. `pod-one,pod-two` wil
 filterAnnotations | | Comma-separated list of annotations to match; e.g. `name:annotation-one,name:annotation-two` will return results with either of those two annotation key-value-pairs.
 filterLabels | | Comma-separated list of annotations to match; e.g. `app:cost-analyzer, app:prometheus` will return results with either of those two label key-value-pairs.
 filterServices | | Comma-separated list of services to match; e.g. `frontend-one,frontend-two` will return results with either of those two services.
+format | | Set to `csv` to download an accumulated version of the allocation results in CSV format. By default, results will be in JSON format.
 shareIdle | false | If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented.
 splitIdle | false | If `true`, and `shareIdle == false` Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "\_idle\_" allocation.
 idleByNode | false | If `true`, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split.
@@ -315,7 +316,7 @@ Both the `reconcile` and `shareTenancyCosts` flags start query-time processes th
 Distribution by Usage Hours takes the usage of the windows (start time and end time) of an Asset and all the Allocations connected to it and finds the number of hours that both the Allocation and Asset were running. The number of hours for each Allocation related to an Asset is called Alloc_Usage_Hours. The sum of all Alloc_Usage_Hours for a single Assets is Total_Usage_Hours. With these values an Assets cost is distributed to each connected Allocation using the formula Asset_Cost * Alloc_Usage_Hours/Total_Usage_Hours. Depending on the Asset type an Allocation can receive proportions of multiple Asset Costs.
 
 Asset types that use this distribution method include:
-- Network (`reconcile`): When the network pod is not enabled cost is distributed by usage hours. If the network pod is enabled cost is distributed to Allocations proportionally to usage. 
+- Network (`reconcile`): When the network pod is not enabled cost is distributed by usage hours. If the network pod is enabled cost is distributed to Allocations proportionally to usage.
 - Load Balancer (`reconcile`)
 - Cluster Management (`shareTenancyCosts`)
 - Attached disks (`shareTenancyCosts`): Does not include PVs, which are handled by `reconcile`

--- a/assets.md
+++ b/assets.md
@@ -1,7 +1,7 @@
-The Kubecost Assets view shows Kubernetes cluster costs broken down by the individual backing assets in your cluster (e.g. cost by node, disk, and other assets). 
+The Kubecost Assets view shows Kubernetes cluster costs broken down by the individual backing assets in your cluster (e.g. cost by node, disk, and other assets).
 It’s used to identify spend drivers over time and to audit Allocation data. This view can also optionally show out of cluster assets by service, tag/label, etc.
 
-> Note: Similar to our Allocation API, the Assets API uses our ETL pipeline whichs aggregates data on a daily basis. This allows for enterprise scale with much higher performance. 
+> Note: Similar to our Allocation API, the Assets API uses our ETL pipeline whichs aggregates data on a daily basis. This allows for enterprise scale with much higher performance.
 
 ![Kubecost Assets view](images/assets-screenshot.png)
 
@@ -27,13 +27,14 @@ Here are example uses:
 API parameters include the following:
 
 * `window` dictates the applicable window for measuring historical asset cost. Currently supported options are as follows:
-    - "15m", "24h", "7d", "48h", etc. 
+    - "15m", "24h", "7d", "48h", etc.
     - "today", "yesterday", "week", "month", "lastweek", "lastmonth"
     - "1586822400,1586908800", etc. (start and end unix timestamps)
     - "2020-04-01T00:00:00Z,2020-04-03T00:00:00Z", etc. (start and end UTC RFC3339 pairs)
 * `aggregate` is used to consolidate cost model data. Supported aggregation types are cluster and type. Passing an empty value for this parameter, or not passing one at all, returns data by individual asset.
 * `accumulate` when set to false this endpoint returns daily time series data vs cumulative data. Default value is false.
 * `disableAdjustments` when set to true, zeros out all adjustments from cloud provider reconciliation, which would otherwise change the totalCost.
+* `format` when set to `csv`, will download an accumulated version of the asset results in CSV format. By default, results will be in JSON format.
 
 This API returns a set of JSON objects in this format:
 
@@ -54,7 +55,7 @@ This API returns a set of JSON objects in this format:
     ramCost: 0.023203
     start: "2020-08-20T00:00:00+0000"
     adjustment: 0.0023 // amount added to totalCost during reconciliation with cloud provider data
-    totalCost: 0.049434 // total asset cost after applied discount 
+    totalCost: 0.049434 // total asset cost after applied discount
     type: "node" // e.g. node, disk, cluster management fee, etc
 }
 ```
@@ -86,7 +87,7 @@ Note:
 
 # Cloud cost reconciliation
 
-After granting Kubecost permission to access cloud billing data, Kubecost adjusts its asset prices once cloud billing data becomes available, e.g. AWS Cost and Usage Report and the spot data feed. Until this data is available from cloud provider, Kubecost uses data from public cloud APIs to determine cost, or alternatively custom pricing sheets. This allows teams to have highly accurate estimates of asset prices in real-time and then become even more precise once cloud billing data becomes available, which is often 1-2 hours for spot nodes and up to a day for reserved instances/savings plans. 
+After granting Kubecost permission to access cloud billing data, Kubecost adjusts its asset prices once cloud billing data becomes available, e.g. AWS Cost and Usage Report and the spot data feed. Until this data is available from cloud provider, Kubecost uses data from public cloud APIs to determine cost, or alternatively custom pricing sheets. This allows teams to have highly accurate estimates of asset prices in real-time and then become even more precise once cloud billing data becomes available, which is often 1-2 hours for spot nodes and up to a day for reserved instances/savings plans.
 
 Note that while cloud adjustments typically lag by roughly a day, there are certain adjustments, e.g. credits, that may continue to come in over the course of the month, and in some cases at the very end of the month, so reconciliation adjustments may continue to update over time.
 


### PR DESCRIPTION
Added documentation to allocation.md and assets.md for the `format=csv` parameter, which enables downloading a CSV version of the data.