### PR TITLE
Update docs for new configurations

### DIFF
--- a/azure-config.md
+++ b/azure-config.md
@@ -44,7 +44,7 @@ The newly created `my_credentials.json` file will contain the relevant configura
 helm install kubecost ./cost-analyzer -n kubecost --set kubecostProductConfigs.azureSubscriptionID=<> --set kubecostProductConfigs.azureClientID=<> --set kubecostProductConfigs.azureTenantID=<> --set kubecostProductConfigs.azureClientPassword=<> --set .kubecostProductConfigs.createServiceKeySecret=true
 ```
 
-> Additionally `kubecostProductConfigs.azureOfferDurableID` can be modified to use the Durable Offer ID of your subscription, which can be found in the Azure Portal in subscriptions. The Default is "MS-AZR-0003p" which is a pay-as-you-go subscription.
+> Additionally `kubecostProductConfigs.azureOfferDurableID` can be modified to use the Offer Durable ID of your subscription, which can be found in the Azure Portal in subscriptions. The Default is "MS-AZR-0003p" which is a pay-as-you-go subscription.
 
 <img width="1792" alt="Screen Shot 2020-12-07 at 12 32 24 PM" src="https://user-images.githubusercontent.com/453512/101402781-12156880-3889-11eb-86ca-55111d36fe14.png">
 

--- a/azure-config.md
+++ b/azure-config.md
@@ -44,6 +44,8 @@ The newly created `my_credentials.json` file will contain the relevant configura
 helm install kubecost ./cost-analyzer -n kubecost --set kubecostProductConfigs.azureSubscriptionID=<> --set kubecostProductConfigs.azureClientID=<> --set kubecostProductConfigs.azureTenantID=<> --set kubecostProductConfigs.azureClientPassword=<> --set .kubecostProductConfigs.createServiceKeySecret=true
 ```
 
+> Additionally `kubecostProductConfigs.azureOfferDurableID` can be modified to use the Durable Offer ID of your subscription, which can be found in the Azure Portal in subscriptions. The Default is "MS-AZR-0003p" which is a pay-as-you-go subscription.
+
 <img width="1792" alt="Screen Shot 2020-12-07 at 12 32 24 PM" src="https://user-images.githubusercontent.com/453512/101402781-12156880-3889-11eb-86ca-55111d36fe14.png">
 
 

--- a/azure-out-of-cluster.md
+++ b/azure-out-of-cluster.md
@@ -31,9 +31,9 @@ with the following format:
 
 ```
 {
-	"azureStorageAccount": "<STORAGE_ACCOUNT_NAME>",
-	"azureStorageAccessKey": "<STORE_ACCESS_KEY>",
-	"azureStorageContainer": "<REPORT_CONTAINER_NAME>",
+  "azureStorageAccount": "<STORAGE_ACCOUNT_NAME>",
+  "azureStorageAccessKey": "<STORE_ACCESS_KEY>",
+  "azureStorageContainer": "<REPORT_CONTAINER_NAME>",
   "azureCloud": "<AZURE_CLOUD>"
 }
 ```

--- a/azure-out-of-cluster.md
+++ b/azure-out-of-cluster.md
@@ -21,7 +21,9 @@ The values needed to provide access to the Azure Storage Account where cost data
 * `<STORAGE_ACCOUNT_NAME>` is the name of the Storage account where the exported CSV is being stored.
 * `<STORE_ACCESS_KEY>` can be found by selecting the “Access Keys” option from the navigation sidebar then selecting “Show Keys”. Using either of the two keys will work. 
 * `<REPORT_CONTAINER_NAME>` is the name that you choose for the exported cost report when you set it up. This is the name of the container where the CSV cost reports are saved in your Storage account. 
-With this value in hand, you can now provide them to Kubecost to allow access to the Azure Storage API.
+* `<AZURE_CLOUD>` is an optional value which denotes the cloud where the storage account exist, possible values are `public` and `gov`. The default is `public`.
+
+With these values in hand, you can now provide them to Kubecost to allow access to the Azure Storage API.
 
 ### Option #1: Manually add secret to cluster (Recommended)
 To create this secret you will need to create a JSON file that must be named azure-storage-config.json
@@ -31,7 +33,8 @@ with the following format:
 {
 	"azureStorageAccount": "<STORAGE_ACCOUNT_NAME>",
 	"azureStorageAccessKey": "<STORE_ACCESS_KEY>",
-	"azureStorageContainer": <REPORT_CONTAINER_NAME>
+	"azureStorageContainer": "<REPORT_CONTAINER_NAME>",
+  "azureCloud": "<AZURE_CLOUD>"
 }
 ```
 

--- a/multi-cloud.md
+++ b/multi-cloud.md
@@ -43,6 +43,7 @@ The values needed to provide access to the Azure Storage Account where cost data
 - <STORAGE_ACCOUNT_NAME> is the name of the Storage account where the exported CSV is being stored.
 - <STORE_ACCESS_KEY> can be found by selecting the “Access Keys” option from the navigation sidebar then selecting “Show Keys”. Using either of the two keys will work.
 - <REPORT_CONTAINER_NAME> is the name that you choose for the exported cost report when you set it up. This is the name of the container where the CSV cost reports are saved in your Storage account.
+- <AZURE_CLOUD> is an optional value which denotes the cloud where the storage account exist, possible values are `public` and `gov`. The default is `public`.
 
 Set these values into the following object and add them to the Azure array:
 ```
@@ -50,7 +51,8 @@ Set these values into the following object and add them to the Azure array:
 	"azureSubscriptionID": "<SUBSCRIPTION_ID>",
 	"azureStorageAccount": "<STORAGE_ACCOUNT_NAME>",
 	"azureStorageAccessKey": "<STORE_ACCESS_KEY>",
-	"azureStorageContainer": <REPORT_CONTAINER_NAME>
+	"azureStorageContainer": <REPORT_CONTAINER_NAME>,
+	"azureCloud": "<AZURE_CLOUD>"
 }
 ```
 


### PR DESCRIPTION
Add documentation for new configurations for Azure. Both of these new configurations are optional. One allows uses to specify ratecard api Durable offer id for more accurate pricing predictions and the other is required to allow integration with gov cloud storage accounts.