### PR TITLE
Explain saved reports values vs ui interaction

### DIFF
--- a/saved-reports.md
+++ b/saved-reports.md
@@ -4,7 +4,7 @@
 
 Saved reports can be managed via [`values.yaml`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml), as well as via the Kubecost UI. These two methods of managing saved reports can be combined. The following rules apply:
 
-- If Helm chart definitions are _unused_ (`global.savedReports.enabled = false`), reports created via the UI are saved to a persistent volume, if one is configured, and persist across pod restarts.
+- If Helm chart definitions are _unused_ (`global.savedReports.enabled = false`), reports created via the UI are saved to a persistent volume, and persist across pod restarts.
 
 - If Helm chart definitions are _used_ (`global.savedReports.enabled = true`), they are registered on pod start. Reports can still be freely created/deleted via the UI. On pod restart, however, whatever is defined in the configmap will supersede all UI changes.
 
@@ -97,8 +97,6 @@ The following fields apply to each map item under the `reports` key:
         filters: [] # if no filters, specify empty array
 
 ```
-
-## Managing reports via Helm vs. the Kubecost UI
 
 ## Troubleshooting
 

--- a/saved-reports.md
+++ b/saved-reports.md
@@ -1,62 +1,67 @@
-Saved Reports
-=============
+# Saved Reports
 
-### Summary
+## Summary
 
-Kubecost supports configuring saved report parameters through [`values.yaml`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml), allowing users to configure multiple saved custom reports on start up in addition to configuration through the UI. This reference outlines the process of configuring saved reports through a values file and provides documentation on the required and optional parameters.
-  
-### Saved Report Parameters  
-  
+Saved reports can be managed via [`values.yaml`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml), as well as via the Kubecost UI. These two methods of managing saved reports can be combined. The following rules apply:
+
+- If Helm chart definitions are _unused_ (`global.savedReports.enabled = false`), reports created via the UI are saved to a persistent volume, if one is configured, and persist across pod restarts.
+
+- If Helm chart definitions are _used_ (`global.savedReports.enabled = true`), they are registered on pod start. Reports can still be freely created/deleted via the UI. On pod restart, however, whatever is defined in the configmap will supersede all UI changes.
+
+Generally, the configmap, if present, serves as the source of truth at startup.
+
+The rest of this document outlines the process of configuring saved reports through a values file and provides documentation on the required and optional parameters.
+
+## Saved Report Parameters
+
 The saved report settings, under `global.savedReports`, accept two parameters:
 
-* `enabled` determines whether Kubecost will read saved reports configured via `values.yaml`; default `false`   
-* `reports` is a list of report parameter maps
-    
+- `enabled` determines whether Kubecost will read saved reports configured via `values.yaml`; default `false`
+- `reports` is a list of report parameter maps
+
 The following fields apply to each map item under the `reports` key:
 
-* `title` the title/name of your custom report; any non-empty string is accepted
-* `window` the time window the allocation report covers, the following values are supported:
-	* key words: `today`, `week` (week-to-date), `month` (month-to-date), `yesterday`, `lastweek`, `lastmonth`
-	* number of days: `{N}d` (last **N** days)
-		* e.g. `30d` for the last 30 days
-	* date range: `{start},{end}` (comma-separated **RFC-3339 date strings** or **unix timestamps**)
-		* e.g. `2021-01-01T00:00:00Z,2021-01-02T00:00:00Z` for the single day of 1 January 2021
-		* e.g. `1609459200,1609545600` for the single day of 1 January 2021
-	* _Note: for all window options, if a window is requested that spans "partial" days, the window will be rounded up to include the nearest full date(s)._
-		* e.g. `2021-01-01T15:04:05Z,2021-01-02T20:21:22Z` will return the two full days of 1 January 2021 and 2 January 2021
-* `aggregateBy` the desired aggregation parameter -- equivalent to *Breakdown* in the Kubecost UI. Supports:
-  * `cluster`
-  * `container`
-  * `controller`
-  * `controllerKind`
-  * `daemonset`
-  * `department`
-  * `deployment`
-  * `environment`
-  * `job`
-  * `label` requires the following format: `label:<label_name>`
-  * `namespace`
-  * `node`
-  * `owner`
-  * `pod`
-  * `product`
-  * `service`
-  * `statefulset`
-  * `team`
-* `idle` idle cost allocation, supports `hide`, `shareByNode`, `shareByCluster`, and `separate`
-* `accumulate` determines whether or not to sum Allocation costs across the entire window -- equivalent to *Resolution* in the UI, supports `true` (Entire window resolution) and `false` (Daily resolution)
-* `filters` -- a list of maps consisting of a property and value
-	* `property` -- supports `cluster`, `node`, `namespace`, and `label`
-	* `value` -- property value(s) to filter on, supports wildcard filtering with a `*` suffix
-		* Special case `label` `value` examples: `app:cost-analyzer`, `app:cost*`
-			* Wildcard filters only apply for the label value. e.g., `ap*:cost-analyzer` is not valid
-	* *Note: multiple filter properties evaluate as ANDs, multiple filter values evaluate as ORs*
-		* *e.g., (namespace=foo,bar), (node=fizz) evaluates as (namespace == foo || namespace == bar) && node=fizz*
-	* **Important:** If no filters used, supply an empty list `[]`
+- `title` the title/name of your custom report; any non-empty string is accepted
+- `window` the time window the allocation report covers, the following values are supported:
+  - key words: `today`, `week` (week-to-date), `month` (month-to-date), `yesterday`, `lastweek`, `lastmonth`
+  - number of days: `{N}d` (last **N** days)
+    - e.g. `30d` for the last 30 days
+  - date range: `{start},{end}` (comma-separated **RFC-3339 date strings** or **unix timestamps**)
+    - e.g. `2021-01-01T00:00:00Z,2021-01-02T00:00:00Z` for the single day of 1 January 2021
+    - e.g. `1609459200,1609545600` for the single day of 1 January 2021
+  - _Note: for all window options, if a window is requested that spans "partial" days, the window will be rounded up to include the nearest full date(s)._
+    - e.g. `2021-01-01T15:04:05Z,2021-01-02T20:21:22Z` will return the two full days of 1 January 2021 and 2 January 2021
+- `aggregateBy` the desired aggregation parameter -- equivalent to _Breakdown_ in the Kubecost UI. Supports:
+  - `cluster`
+  - `container`
+  - `controller`
+  - `controllerKind`
+  - `daemonset`
+  - `department`
+  - `deployment`
+  - `environment`
+  - `job`
+  - `label` requires the following format: `label:<label_name>`
+  - `namespace`
+  - `node`
+  - `owner`
+  - `pod`
+  - `product`
+  - `service`
+  - `statefulset`
+  - `team`
+- `idle` idle cost allocation, supports `hide`, `shareByNode`, `shareByCluster`, and `separate`
+- `accumulate` determines whether or not to sum Allocation costs across the entire window -- equivalent to _Resolution_ in the UI, supports `true` (Entire window resolution) and `false` (Daily resolution)
+- `filters` -- a list of maps consisting of a property and value
+  - `property` -- supports `cluster`, `node`, `namespace`, and `label`
+  - `value` -- property value(s) to filter on, supports wildcard filtering with a `*` suffix
+    - Special case `label` `value` examples: `app:cost-analyzer`, `app:cost*`
+      - Wildcard filters only apply for the label value. e.g., `ap*:cost-analyzer` is not valid
+  - _Note: multiple filter properties evaluate as ANDs, multiple filter values evaluate as ORs_
+    - _e.g., (namespace=foo,bar), (node=fizz) evaluates as (namespace == foo || namespace == bar) && node=fizz_
+  - **Important:** If no filters used, supply an empty list `[]`
 
-### Example Helm values.yaml Saved Reports Section
-
-*Note: `values.yaml` will overwrite any previously saved reports. Any reports saved afterward through the UI will also be overwritten on restart.*
+## Example Helm values.yaml Saved Reports Section
 
 ```
    # Set saved report(s) accessible in reports.html
@@ -93,7 +98,9 @@ The following fields apply to each map item under the `reports` key:
 
 ```
 
-### Troubleshooting
+## Managing reports via Helm vs. the Kubecost UI
+
+## Troubleshooting
 
 Review these steps to verify that saved reports are being passed to the Kubecost application correctly:
 
@@ -101,10 +108,10 @@ Review these steps to verify that saved reports are being passed to the Kubecost
 
 2. Ensure that the Helm values are successfully read into the configmap
 
--   Run `helm template ./cost-analyzer -n kubecost > test-saved-reports-config.yaml`
--   Open `test-saved-reports-config`
--   Find the section starting with `# Source: cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml`
--   Ensure that the Helm values are successfully read into the configmap under the `data` field. Example below.
+- Run `helm template ./cost-analyzer -n kubecost > test-saved-reports-config.yaml`
+- Open `test-saved-reports-config`
+- Find the section starting with `# Source: cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml`
+- Ensure that the Helm values are successfully read into the configmap under the `data` field. Example below.
 
 ```
 # Source: cost-analyzer/templates/cost-analyzer-saved-reports-configmap.yaml
@@ -113,7 +120,7 @@ kind: ConfigMap
 metadata:
   name: saved-report-configs
   labels:
-    
+
     app.kubernetes.io/name: cost-analyzer
     helm.sh/chart: cost-analyzer-1.70.0
     app.kubernetes.io/instance: RELEASE-NAME
@@ -125,8 +132,7 @@ data:
 
 3. Ensure that the json string is successfully mapped to the appropriate configs
 
--   Navigate to `<front-end-url>/model/reports` and ensure that the configured report parameters have been set by selecting the "Open saved reports" button in the upper right hand corner of the report card.
-
+- Navigate to `<front-end-url>/model/reports` and ensure that the configured report parameters have been set by selecting the "Open saved reports" button in the upper right hand corner of the report card.
 
 Edit this doc on [Github](https://github.com/kubecost/docs/blob/main/saved-reports.md)
 

--- a/saved-reports.md
+++ b/saved-reports.md
@@ -2,15 +2,7 @@
 
 ## Summary
 
-Saved reports can be managed via [`values.yaml`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml), as well as via the Kubecost UI. These two methods of managing saved reports can be combined. The following rules apply:
-
-- If Helm chart definitions are _unused_ (`global.savedReports.enabled = false`), reports created via the UI are saved to a persistent volume, and persist across pod restarts.
-
-- If Helm chart definitions are _used_ (`global.savedReports.enabled = true`), they are registered on pod start. Reports can still be freely created/deleted via the UI. On pod restart, however, whatever is defined in the configmap will supersede all UI changes.
-
-Generally, the configmap, if present, serves as the source of truth at startup.
-
-The rest of this document outlines the process of configuring saved reports through a values file and provides documentation on the required and optional parameters.
+Saved reports can be managed via [`values.yaml`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml), or via the Kubecost UI, or both. This reference outlines the process of configuring saved reports through a values file, and provides documentation on the required and optional parameters.
 
 ## Saved Report Parameters
 
@@ -97,6 +89,14 @@ The following fields apply to each map item under the `reports` key:
         filters: [] # if no filters, specify empty array
 
 ```
+
+## Combining UI Report Management with `values.yaml`
+
+When defining reports via `values.yaml`, by setting `global.savedReports.enabled = true` in the values file, the reports defined in `values.yaml` are created when the Kubecost pod starts. Reports can still be freely created/deleted via the UI while the pod is running. However, when the pod restarts, whatever is defined the the values file supersedes any UI changes.
+
+Generally, the configmap, if present, serves as the source of truth at startup.
+
+If saved reports are _not_ provided via `values.yaml`, meaning `global.savedReports.enabled = false`, reports created via the UI are saved to a persistent volume, and persist across pod restarts.
 
 ## Troubleshooting
 


### PR DESCRIPTION
* Modified the Summary section of the saved reports document to explain the interaction between UI-managed and configmap-managed reports
* Removed the footnote on this interaction since it is now explained more fully
* Changed the h3 headings to be h2 for semantic correctness and style reasons

EDIT: Also apparently Prettier changed a lot of `*` to `-` and trimmed trailing whitespace. I'm fine with changing the `-` back to `*` if anyone feels strongly about that