### PR TITLE
Remove deprecated server port

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -9,7 +9,6 @@ Kubecost components use following ports by default:
 | ingress https                                     | 443   |
 | grafana                                           | 3000  |
 | cost-analyzer                                     | 3001  |
-| cost-analyzer-service - tcp-server                | 9001  |
 | cost-analyzer-service - tcp-model                 | 9003  |
 | cost-analyzer-service - api-server                | 9004  |
 | prometheus service                                | 9090  |


### PR DESCRIPTION
Removes documentation for deprecated `cost-analyzer-service - tcp-server` port. 

Accompanied PR: https://github.com/kubecost/cost-analyzer-helm-chart/pull/1339