### PR TITLE
Update long-term-storage.md

### DIFF
--- a/long-term-storage.md
+++ b/long-term-storage.md
@@ -36,8 +36,8 @@ These values can be adjusted under the `thanos` block in `values-thanos.yaml` - 
 It's *important* to note that when running `helm install`, you must provide the base `values.yaml` followed by the override [values-thanos.yaml](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values-thanos.yaml). For example:
 
 ```shell
-helm install kubecost/cost-analyzer \
-    --name kubecost \
+helm upgrade kubecost kubecost/cost-analyzer \
+    --install \
     --namespace kubecost \
     -f values.yaml \
     -f values-thanos.yaml


### PR DESCRIPTION
Updated the long-term-storage doc. Removed the depreciated --name flag, added the new name specification command, and changed "helm install" to "help upgrade --install" to avoid confusion when Kubecost is already installed as a release (if a release by this name doesn't already exist, run an install). 