### PR TITLE
Add AWS account-level tags documentation

### DIFF
--- a/aws-out-of-cluster.md
+++ b/aws-out-of-cluster.md
@@ -50,6 +50,8 @@ If a resource has a label with the same name as an account-level tag, the resour
 
 Modifications incurred on account-level tags may take several hours to update on Kubecost. Note that upon such a modification, historical data going back 15 days will be updated to contain the new tag values.
 
+Your AWS account will need to support the `organizations:ListAccounts` and `organizations:ListTagsForResource` policies to benefit from this feature.
+
 ## Having issues?
 
 

--- a/aws-out-of-cluster.md
+++ b/aws-out-of-cluster.md
@@ -48,7 +48,7 @@ You can view AWS account-level tags in Kubecost; tags are applied to all the res
 
 If a resource has a label with the same name as an account-level tag, the resource label value will take precedence; it won't be overriden by the value of the account-level tag.
 
-Modifications incurred on account-level tags may take several hours to update on Kubecost, however, note that historical data will be modified back 15 days only.
+Modifications incurred on account-level tags may take several hours to update on Kubecost. Note that upon such a modification, historical data going back 15 days will be updated to contain the new tag values.
 
 ## Having issues?
 

--- a/aws-out-of-cluster.md
+++ b/aws-out-of-cluster.md
@@ -46,7 +46,7 @@ Instructions for enabling user-defined cost allocation tags [here](https://docs.
 
 You can view AWS account-level tags in Kubecost; tags are applied to all the resources defined under a given AWS account. You can filter AWS resources in the Kubecost Assets View (or API) by account-level tags by adding them ('tag:value') in the Label/Tag filter. 
 
-If a resource has a label with the same name as an account-level tag, the resource label value will take precedence; it won't be overriden by the value of the account-level tag.
+If a resource has a label with the same name as an account-level tag, the resource label value will take precedence; it won't be overridden by the value of the account-level tag.
 
 Modifications incurred on account-level tags may take several hours to update on Kubecost. Note that upon such a modification, historical data going back 15 days will be updated to contain the new tag values.
 

--- a/aws-out-of-cluster.md
+++ b/aws-out-of-cluster.md
@@ -42,6 +42,14 @@ In order to make the custom Kubecost AWS tags appear on the cost and usage repor
 
 Instructions for enabling user-defined cost allocation tags [here](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html)
 
+## Viewing account-level tags
+
+You can view AWS account-level tags in Kubecost; tags are applied to all the resources defined under a given AWS account. You can filter AWS resources in the Kubecost Assets View (or API) by account-level tags by adding them ('tag:value') in the Label/Tag filter. 
+
+If a resource has a label with the same name as an account-level tag, the resource label value will take precedence; it won't be overriden by the value of the account-level tag.
+
+Modifications incurred on account-level tags may take several hours to update on Kubecost, however, note that historical data will be modified back 15 days only.
+
 ## Having issues?
 
 


### PR DESCRIPTION
This PR adds documentation on how AWS account-level tags are supported in Kubecost Assets view.

addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/946