### PR TITLE
Add line detailing editor role functionality

### DIFF
--- a/user-management.md
+++ b/user-management.md
@@ -12,6 +12,7 @@ High-level access control options:
 * **Pre-defined user roles**
     * admin: full control with permissions to manage users, configure model inputs, and application settings.
     * readonly: user role with read-only permission
+    * editor: role can change and build alerts and reports, but cannot edit appliaction settings and otherwise functions as read-only.
 
 <br/>
 

--- a/user-management.md
+++ b/user-management.md
@@ -12,7 +12,7 @@ High-level access control options:
 * **Pre-defined user roles**
     * admin: full control with permissions to manage users, configure model inputs, and application settings.
     * readonly: user role with read-only permission
-    * editor: role can change and build alerts and reports, but cannot edit appliaction settings and otherwise functions as read-only.
+    * editor: role can change and build alerts and reports, but cannot edit application settings and otherwise functions as read-only.
 
 <br/>
 


### PR DESCRIPTION
Adds a line detailing the functionality of the 1.94 editor role for SAML RBAC.

Eventually I think there should be a more in-depth explanation of the behavior of the predefined RBAC roles, but for now this should clarify how this role works and what it can do.