### PR TITLE
Add GCP project-level labels usage info 

### DIFF
--- a/aws-out-of-cluster.md
+++ b/aws-out-of-cluster.md
@@ -41,11 +41,11 @@ Instructions for enabling user-defined cost allocation tags [here](https://docs.
 
 ## Viewing account-level tags
 
-You can view AWS account-level tags in Kubecost; tags are applied to all the resources defined under a given AWS account. You can filter AWS resources in the Kubecost Assets View (or API) by account-level tags by adding them ('tag:value') in the Label/Tag filter. 
+Account-level tags are applied (as labels) to all the Assets built from resources defined under a given AWS account. You can filter AWS resources in the Kubecost Assets View (or API) by account-level tags by adding them ('tag:value') in the Label/Tag filter.
 
-If a resource has a label with the same name as an account-level tag, the resource label value will take precedence; it won't be overridden by the value of the account-level tag.
+If a resource has a label with the same name as an account-level tag, the resource label value will take precedence.
 
-Modifications incurred on account-level tags may take several hours to update on Kubecost. Note that upon such a modification, historical data going back 15 days will be updated to contain the new tag values.
+Modifications incurred on account-level tags may take several hours to update on Kubecost.
 
 Your AWS account will need to support the `organizations:ListAccounts` and `organizations:ListTagsForResource` policies to benefit from this feature.
 

--- a/cloud-integration.md
+++ b/cloud-integration.md
@@ -22,6 +22,8 @@ Cost-based [metrics](https://github.com/kubecost/cost-model/blob/develop/PROMETH
 2. Once the node is added to the cloud bill, Kubecost starts emitting something closer to the actual price.
 3. For the time period where Kubecost assumed the node was onDemand but it was actually reserved, reconciliation fixes the price in ETL.
 
+Note: The reconciled Assets will inherit the labels from the corresponding items in the billing data.
+
 ### Cloud Assets
 The Cloud Assets process allows Kubecost to pull in out-of-cluster cloud spend from your Cloud Service Provider's billing data. This includes any services run by the Cloud Service Provider in addition to compute resources outside of clusters monitored by Kubecost. Additionally, by labeling these Cloud Assets their cost can be distributed to Allocations as external costs. This can help teams get a better understanding of the proportion of out-of-cluster cloud spend that their in-cluster usage is dependant on. Cloud Assets become available as soon as they appear in the billing data, with the 6 to 24 hour delay mentioned above, and are updated as they become more complete.
 

--- a/cloud-integration.md
+++ b/cloud-integration.md
@@ -22,7 +22,7 @@ Cost-based [metrics](https://github.com/kubecost/cost-model/blob/develop/PROMETH
 2. Once the node is added to the cloud bill, Kubecost starts emitting something closer to the actual price.
 3. For the time period where Kubecost assumed the node was onDemand but it was actually reserved, reconciliation fixes the price in ETL.
 
-Note: The reconciled Assets will inherit the labels from the corresponding items in the billing data.
+Note: The reconciled Assets will inherit the labels from the corresponding items in the billing data. If there exist identical label keys between the original assets and those of the billing data items, the label value of the original asset will take precedence.
 
 ### Cloud Assets
 The Cloud Assets process allows Kubecost to pull in out-of-cluster cloud spend from your Cloud Service Provider's billing data. This includes any services run by the Cloud Service Provider in addition to compute resources outside of clusters monitored by Kubecost. Additionally, by labeling these Cloud Assets their cost can be distributed to Allocations as external costs. This can help teams get a better understanding of the proportion of out-of-cluster cloud spend that their in-cluster usage is dependant on. Cloud Assets become available as soon as they appear in the billing data, with the 6 to 24 hour delay mentioned above, and are updated as they become more complete.

--- a/gcp-out-of-cluster.md
+++ b/gcp-out-of-cluster.md
@@ -87,6 +87,14 @@ To use an alternative or existing label schema for GCP cloud assets, you may sup
 
 > Note: Google generates special labels for GKE resources (e.g. "goog-gke-node", "goog-gke-volume"). Values with these labels are excluded from out-of-cluster costs because Kubecost already includes them as in-cluster assets. Thus, to make sure all cloud assets are included, we recommend installing Kubecost on each cluster where insights into costs are required.
 
+### Viewing project-level labels
+
+Project-level labels are applied to all the Assets built from resources defined under a given GCP project. You can filter GCP resources in the Kubecost Assets View (or API) by project-level labels by adding them ('label:value') in the Label/Tag filter.
+
+If a resource has a label with the same name as a project-level label, the resource label value will take precedence.
+
+Modifications incurred on project-level labels may take several hours to update on Kubecost.
+
 ## Cross-Project Service Account Configuration
 
 Due to organizational constraints, it is common that Kubecost must be run in a separate project from the project containing the billing data Big Query dataset which is needed for Cloud Integration. It is still possible to configure Kubecost in this scenario, but some of the values in the above script will need to be changed. First you will need the project id of the projects where Kubecost is installed and where the Big Query dataset is located. Additionally you will need a `gcloud` user with the permissions `iam.serviceAccounts.setIamPolicy` for the kubecost project and the ability to manage the roles listed above for the Big Query Project. With these fill in the following script to set the relevant variables:


### PR DESCRIPTION
This PR adds some notes on the support of project-level labels on GCP and refactors the corresponding AWS section to match in formatting.

This PR should **not** be merged until the corresponding implementation PR has been merged: https://github.com/kubecost/kubecost-cost-model/pull/837

Original issue: https://github.com/kubecost/cost-analyzer-helm-chart/issues/946