### PR TITLE
Update architecture.md

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -10,7 +10,7 @@ Below are the major components deployed with the [Kubecost helm chart](http://do
 2. **Prometheus**  
     a. Prometheus server -- time-series data store for cost & health metrics  
     b. Kube-state-metrics -- provides Kubernetes API metrics, e.g. resource requests  
-    c. Node-exporter -- provides node-level utilization metrics for right-sizing recommendations and cluster utilization
+    c. Node-exporter -- provides node-level utilization metrics for right-sizing recommendations and cluster utilization  
     d. Pushgateway -- provides the ability for users to push new metrics to Prometheus [Optional]  
     e. Alertmanager -- used for custom alerts  [Optional] 
 3. **Network costs** -- optional DaemonSet for collecting network metrics [learn more](https://github.com/kubecost/docs/blob/main/network-allocation.md)


### PR DESCRIPTION
Fixing the list of core components KC can run with - This was mistakenly written as 3a/3b, when those don't exist. Correcting this to say 2a (Prom Server) and 2b (KSM)