### PR TITLE
add notes for cadvisor legacy rules

### DIFF
--- a/custom-prom.md
+++ b/custom-prom.md
@@ -53,6 +53,44 @@ To confirm this job is successfully scraped by Prometheus, you can view the Targ
 
 ![Prometheus Targets](https://raw.githubusercontent.com/kubecost/docs/main/prom-targets.png)
 
+## Cadvisor metric labels
+
+Kubecost uses `container_name` and `pod_name` labels on cadvisor metrics. For clusters running **k8s v1.16+**, the following relabel config creates the expected labels on cadvisor metrics:
+
+```
+  metric_relabel_configs:
+  - source_labels: [ container ]
+    target_label: container_name
+    regex: (.+)
+    action: replace
+  - source_labels: [ pod ]
+    target_label: pod_name
+    regex: (.+)
+    action: replace
+```
+
+For clusters running **k8s v1.15 or below**, you will need to adjust the relabel config in your [values.yaml](https://github.com/kubecost/cost-analyzer-helm-chart/blob/5fa8e0b590744c92aec820d36f37205b18a2fea2/cost-analyzer/charts/prometheus/values.yaml#L1206-L1217) so that all 4 rules (`container_name`, `container`, `pod_name`, and `pod`) are all recorded:
+
+```
+  metric_relabel_configs:
+  - source_labels: [ container_name ]
+    target_label: container
+    regex: (.+)
+    action: replace
+  - source_labels: [ pod_name ]
+    target_label: pod
+    regex: (.+)
+    action: replace 
+  - source_labels: [ container ]
+    target_label: container_name
+    regex: (.+)
+    action: replace
+  - source_labels: [ pod ]
+    target_label: pod_name
+    regex: (.+)
+    action: replace
+```
+
 ## Node exporter metric labels
 
 > Note that this step is optional, and only impacts certain efficiency metrics. View [issue/556](https://github.com/kubecost/cost-model/issues/556) for a description of what will be missing if this step is skipped.

--- a/custom-prom.md
+++ b/custom-prom.md
@@ -3,16 +3,16 @@ Prometheus Configuration Guide
 
 ## Bring your own Prometheus
 
-When integrating Kubecost with an existing Prometheus, we recommend first installing Kubecost with a bundled Prometheus ([instructions](http://kubecost.com/install)) as a dry run before integrating with an external Prometheus deployment. You can get in touch (support@kubecost.com) or via our [Slack community](https://join.slack.com/t/kubecost/shared_invite/enQtNTA2MjQ1NDUyODE5LWFjYzIzNWE4MDkzMmUyZGU4NjkwMzMyMjIyM2E0NGNmYjExZjBiNjk1YzY5ZDI0ZTNhZDg4NjlkMGRkYzFlZTU) for assistance.
+When integrating Kubecost with an existing Prometheus, we recommend first installing Kubecost with a bundled Prometheus ([instructions](http://kubecost.com/install)) as a dry run before integrating with an external Prometheus deployment.
 
 The Kubecost Prometheus deployment is used both as a source and store of metrics. It’s optimized to not interfere with other observability instrumentation and by default only contains metrics that are useful to the Kubecost product. This results in __70-90% fewer metrics__ than a Prometheus deployment using default settings.
 
-For the best experience, we generally recommend teams use the bundled prometheus-server & grafana but reuse their existing kube-state-metrics and node-exporter deployments if they already exist. This setup allows for the easiest installation process, easiest ongoing maintenance, minimal duplication of metrics, and more flexible metric retention.
+For the best experience, we generally recommend teams use the bundled prometheus-server and Grafana but reuse their existing kube-state-metrics and node-exporter deployments if they already exist. This setup allows for the easiest installation process, easiest ongoing maintenance, minimal duplication of metrics, and more flexible metric retention.
 
-> Note: the Kubecost team provides best efforts support for free/community users when integrating with an existing Prometheus deployment.
+> **Note**: The Kubecost team provides best efforts support for free/community users when integrating with an existing Prometheus deployment.
 
 
-## Dependency Requirements
+## Dependency requirements
 
 Kubecost requires the following minimum versions:
 
@@ -20,18 +20,18 @@ Kubecost requires the following minimum versions:
 - cAdvisor - kubelet v1.11.0+ (May 18)
 - node-exporter - v0.16+ (May 18) [Optional]
 
-## Implementation Steps
+## Implementation steps
 
 1. Pass the following parameters in your helm [values file](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml):
 
    * `global.prometheus.fqdn` to match your local Prometheus service address with this format ` http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc`
    * `global.prometheus.enabled` set to `false`
 
-    Pass this updated file to the Kubecost helm install command with `--values values.yaml`
+    Pass this updated file to the Kubecost Helm install command with `--values values.yaml`
 
     Or add `--set global.prometheus.fqdn=http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc --set global.prometheus.enabled=false` the end of your helm install command
 
-1. Have your Prometheus scrape the cost-model `/metrics` endpoint. These metrics are needed for reporting accurate pricing data. Here is an example scrape config:
+2. Have your Prometheus scrape the cost-model `/metrics` endpoint. These metrics are needed for reporting accurate pricing data. Here is an example scrape config:
 
 ```yaml
 - job_name: kubecost
@@ -47,15 +47,15 @@ Kubecost requires the following minimum versions:
         port: 9003
 ```
 
-This config needs to be added to  `extraScrapeConfigs` in the Prometheus configuration. Example [extraScrapeConfigs.yaml](https://raw.githubusercontent.com/kubecost/docs/main/extraScrapeConfigs.yaml)
+This config needs to be added to `extraScrapeConfigs` in the Prometheus configuration. Example [extraScrapeConfigs.yaml](https://raw.githubusercontent.com/kubecost/docs/main/extraScrapeConfigs.yaml)
 
-To confirm this job is successfully scraped by Prometheus, you can view the Targets page in Prometheus and look for a job named `kubecost`.
+To confirm this job is successfully scraped by Prometheus, view the Targets page in Prometheus and look for a job named `kubecost`.
 
 ![Prometheus Targets](https://raw.githubusercontent.com/kubecost/docs/main/prom-targets.png)
 
-## Cadvisor metric labels
+## cAdvisor metric labels
 
-Kubecost uses `container_name` and `pod_name` labels on cadvisor metrics. For clusters running **k8s v1.16+**, the following relabel config creates the expected labels on cadvisor metrics:
+Kubecost uses `container_name` and `pod_name` labels on cAdvisor metrics. For clusters running **k8s v1.16+**, the following relabel config creates the expected labels on cAdvisor metrics:
 
 ```
   metric_relabel_configs:
@@ -93,7 +93,7 @@ For clusters running **k8s v1.15 or below**, you will need to adjust the relabel
 
 ## Node exporter metric labels
 
-> Note that this step is optional, and only impacts certain efficiency metrics. View [issue/556](https://github.com/kubecost/cost-model/issues/556) for a description of what will be missing if this step is skipped.
+> **Note** This step is optional, and only impacts certain efficiency metrics. View [issue/556](https://github.com/kubecost/cost-model/issues/556) for a description of what will be missing if this step is skipped.
 
 You'll need to add the following relabel config to the job that scrapes the node exporter DaemonSet.
 
@@ -109,9 +109,9 @@ You'll need to add the following relabel config to the job that scrapes the node
         target_label: kubernetes_node
 ```
 
-Note that this does not override the source label-- it creates a new label called "kubernetes_node" and copies the value of pod into it.
+> **Note**: This does not override the source label-- it creates a new label called "kubernetes_node" and copies the value of pod into it.
 
-## Troubleshooting Issues
+## Troubleshooting issues
 
 Visiting `<your-kubecost-endpoint>/diagnostics.html` provides diagnostics info on this integration. [More details](/diagnostics.md)
 
@@ -134,7 +134,7 @@ If the config file is not returned, this is an indication that an incorrect Prom
 
 * Data incorrectly is a single namespace -- make sure that [honor_labels](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) is enabled
 
-You can visit Settings in Kubecost to see basic diagnostic information on these Prometheus metrics:
+Visit the Settings page in Kubecost to see basic diagnostic information on these Prometheus metrics:
 
 ![Prometheus status diagnostic](https://raw.githubusercontent.com/kubecost/docs/main/prom-status.png)
 


### PR DESCRIPTION
Adding documentation for CAdvisor metrics within legacy environments. Based on [this previous PR
](https://github.com/kubecost/docs/pull/119)
- Related to https://github.com/kubecost/opencost/issues/1271