### PR TITLE
Update custom-prom.md

### DIFF
--- a/custom-prom.md
+++ b/custom-prom.md
@@ -43,7 +43,7 @@ Kubecost requires the following minimum versions:
     helm upgrade --install kubecost \
       --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
       --namespace kubecost --create-namespace \
-      --set global.prometheus.fqdn=http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc:port \
+      --set global.prometheus.fqdn=http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc \
       --set global.prometheus.enabled=false
     ```
 


### PR DESCRIPTION
We dont require "port" to be appended to the helm upgrade command. I worked with a customer during troubleshooting we have removed "port" in the command and ran the helm upgrade it worked fine.
--set global.prometheus.fqdn=http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc:port