### PR TITLE
Typo Redhat -> Red Hat

### DIFF
--- a/openshift-kubecost-install.md
+++ b/openshift-kubecost-install.md
@@ -1,14 +1,14 @@
-Install Kubecost on Redhat OpenShift cluster
+Install Kubecost on Red Hat OpenShift cluster
 ==================
 
 # Overview
 
-In this documentation, you will learn how to deploy Kubecost on the Redhat OpenShift cluster with step-by-step instructions. Next, let's start with the Architecture overview and then move forward to the installation section for instructions. 
+In this documentation, you will learn how to deploy Kubecost on the Red Hat OpenShift cluster with step-by-step instructions. Next, let's start with the Architecture overview and then move forward to the installation section for instructions. 
 
 ---
 ## Architecture overview:
 
-Currently, there are 2 main options to deploy Kubecost on Redhat OpenShift Cluster (OCP).
+Currently, there are 2 main options to deploy Kubecost on Red Hat OpenShift Cluster (OCP).
 
 ### Standard deployment:
 


### PR DESCRIPTION
Fix typo in OpenShift documentation. "Redhat" changed to "Red Hat".  Resolves  #346 