### PR TITLE
Simplify OCP Helm install process

### DIFF
--- a/openshift-kubecost-install.md
+++ b/openshift-kubecost-install.md
@@ -48,10 +48,10 @@ helm upgrade --install kubecost \
 
 If you want to install Kubecost with your desired cluster name, you can use the following commands:
 
-> **Note**: remember to replace CLUSTER_NAME by your desired value 
+> **Note**: remember to replace CLUSTER_ID's value by your desired value
 
 ```bash
-export CLUSTER_ID="CLUSTER_NAME"
+export CLUSTER_ID="CLUSTER_OCP"
 
 helm upgrade --install kubecost \
 --repo https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main cost-analyzer \
@@ -79,13 +79,8 @@ oc adm policy add-scc-to-user hostmount-anyuid system:serviceaccount:kubecost:gr
 ```
 
 #### Installation:
-
-##### Step 1: Clone this repository to your dev environment.
-
-`git clone https://github.com/kubecost/openshift-helm-chart.git`
-`cd openshift-helm-chart`
    
-##### Step 2: Install the Grafana Agent on your cluster.
+##### Step 1: Install the Grafana Agent on your cluster.
 
 On the existing K8s cluster that you intend to install Kubecost, run the following commands to install Grafana agent to scrape the metrics from Kubecost /metrics endpoint. The script below installs Grafana agent with the necessary scraping configuration for Kubecost, you may want to add an additional scrape configuration for your setup. Please remember to replace the following values with your actual Grafana cloud's values:
 
@@ -408,11 +403,11 @@ MANIFEST_URL=https://raw.githubusercontent.com/kubecost/openshift-helm-chart/mai
 
 To learn more about how to install and config Grafana agent as well as additional scrape configuration, please refer to [Grafana Agent for Kubernetes](https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/k8s_agent_metrics/) section of the Grafana Cloud documentation. Or you can check Kubecost Prometheus scrape config at this [Github repository](https://github.com/kubecost/cost-analyzer-helm-chart/blob/ebe7e088debecd23f90e6dd75b425828901a246c/cost-analyzer/charts/prometheus/values.yaml#L1152)
 
-##### Step 3: Verify if grafana-agent is scraping data successfully.
+##### Step 2: Verify if grafana-agent is scraping data successfully.
 
 `kubectl -n kubecost logs grafana-agent-0`
 
-##### Step 4: Create dbsecret to allow Kubecost to query the metrics from Grafana Cloud Prometheus.
+##### Step 3: Create dbsecret to allow Kubecost to query the metrics from Grafana Cloud Prometheus.
 
 - Create two files in your working directory, called `USERNAME` and `PASSWORD` respectively
   
@@ -440,7 +435,7 @@ kubectl create secret generic dbsecret \
 ```Bash
 kubectl -n kubecost get secret dbsecret -o json | jq '.data | map_values(@base64d)'
 ```
-#### Step 5 (optional): Configure Kubecost recording rules for Grafana Cloud using cortextool.
+#### Step 4 (optional): Configure Kubecost recording rules for Grafana Cloud using cortextool.
 
 To set up recording rules in Grafana Cloud, download the [cortextool CLI utility](https://github.com/grafana/cortex-tools). While they are optional, they offer improved performance.
 
@@ -505,9 +500,11 @@ cortextool rules print \
 --id=<REPLACE-WITH-GRAFANA-PROM-REMOTE-WRITE-USERNAME> \
 --key=<REPLACE-WITH-GRAFANA-PROM-REMOTE-WRITE-API-KEY>
 ```
-##### Step 6: Install Kubecost on the cluster.
+##### Step 5: Install Kubecost on the cluster.
 
 Install Kubecost on your K8s cluster with Grafana Cloud Prometheus query endpoint and `dbsecret` you created in Step 4
+
+> **Note**: remember to replace CLUSTER_ID's value by your desired value 
 
 ```Bash
 export CLUSTER_ID="CLUSTER_OCP"

--- a/openshift-kubecost-install.md
+++ b/openshift-kubecost-install.md
@@ -37,21 +37,28 @@ The Grafana managed Prometheus deployment is illustrated in the following diagra
 
 #### Installation:
 
-##### Step 1: Clone this repository to your dev environment.
-
-`git clone https://github.com/kubecost/openshift-helm-chart.git`
-`cd openshift-helm-chart`
-
-##### Step 2: Update configuration.
-
-Replace `$CLUSTER_NAME` with your desired value in this file [values-openshift.yaml](https://github.com/kubecost/openshift-helm-chart/blob/main/values-openshift.yaml)
-
-##### Step 3: Install Kubecost.
-
-Then install against the local cost-analyzer repo using the following helm install command:
+Run the following helm install command to install Kubecost:
 
 ```bash
-helm upgrade --install kubecost ./cost-analyzer --namespace kubecost --create-namespace -f ./values-openshift.yaml
+helm upgrade --install kubecost \
+--repo https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main cost-analyzer \
+--namespace kubecost --create-namespace \
+-f https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main/values-openshift.yaml
+```
+
+If you want to install Kubecost with your desired cluster name, you can use the following commands:
+
+> **Note**: remember to replace CLUSTER_NAME by your desired value 
+
+```bash
+export CLUSTER_ID="CLUSTER_NAME"
+
+helm upgrade --install kubecost \
+--repo https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main cost-analyzer \
+--namespace kubecost --create-namespace \
+-f https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main/values-openshift.yaml \
+--set kubecostProductConfigs.clusterName=${CLUSTER_ID} \
+--set prometheus.server.global.external_labels.cluster_id=${CLUSTER_ID}
 ```
 
 Wait for all pods to be ready.
@@ -503,13 +510,20 @@ cortextool rules print \
 Install Kubecost on your K8s cluster with Grafana Cloud Prometheus query endpoint and `dbsecret` you created in Step 4
 
 ```Bash
+export CLUSTER_ID="CLUSTER_OCP"
+# Replace REPLACE-WITH-GRAFANA-PROM-QUERY-ENDPOINT with your Grafana cloud value. Example: https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom/
+export GRAFANA_QUERY_ENDPOINT="REPLACE-WITH-GRAFANA-PROM-QUERY-ENDPOINT"
 
-helm upgrade -i -n kubecost kubecost ./cost-analyzer \
-    --set kubecostModel.promClusterIDLabel=cluster \
-    --set global.prometheus.fqdn=https://<REPLACE-WITH-GRAFANA-PROM-QUERY-ENDPOINT> \
-    --set global.prometheus.enabled=false \
-    --set global.prometheus.queryServiceBasicAuthSecretName=dbsecret
-
+helm upgrade --install kubecost \
+--repo https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main cost-analyzer \
+--namespace kubecost --create-namespace \
+-f https://raw.githubusercontent.com/kubecost/openshift-helm-chart/main/values-openshift.yaml \
+--set kubecostProductConfigs.clusterName=${CLUSTER_ID} \
+--set prometheus.server.global.external_labels.cluster_id=${CLUSTER_ID} \
+--set kubecostModel.promClusterIDLabel=cluster \
+--set global.prometheus.fqdn=${GRAFANA_QUERY_ENDPOINT} \
+--set global.prometheus.enabled=false \
+--set global.prometheus.queryServiceBasicAuthSecretName=dbsecret
 ```
 
 The process is complete. By now, you should have successfully completed the Kubecost integration with Grafana Cloud.


### PR DESCRIPTION
Simplify OCP Helm install process:
- Remove git clone steps
- Add few improvements to both deployment method to allow users to just copy and paste to install Kubecost.

cc: @jessegoodier for your visibility. I'm going to make similar changes on Openshift blog post.