### PR TITLE
fix broken link in aws-cloud integration documentation

### DIFF
--- a/aws-cloud-integrations.md
+++ b/aws-cloud-integrations.md
@@ -382,13 +382,13 @@ Now that the policies have been created, we will need to attach those policies t
 
 <ul>
 <li>First, create an OIDC provider for your cluster with these <a href="https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html">steps</a></li>
-<li>Next, create a Role with these <a href="https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html">steps</a>.
+<li>Next, create a Role with these <a href="https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html">steps</a>.
 
 <ul>
-<li>When asked to attach policies, you&rsquo;ll want to attach the policies created above in Step 2</li>
+<li>When asked to attach policies, you&rsquo;ll want to attach the policies created above in Step 3</li>
 <li>When asked for &ldquo;namespace&rdquo; and &ldquo;serviceaccountname&rdquo; use the namespace Kubecost is installed in and the name of the serviceaccount attached to the cost-analyzer pod. You can find that name by running <code>kubectl get pods kubecost-cost-analyzer-69689769b8-lf6nq -n &lt;kubecost-namespace&gt; -o yaml | grep serviceAccount</code></li>
 </ul></li>
-<li>Then, you need to add an annotation to that service account as described in these <a href="https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html">docs</a>. This annotation can be added to the Kubecost service account by setting <code>.Values.serviceAccount.annotations</code> in the helm chart to <code>eks.amazonaws.com/role-arn: arn:aws:iam::&lt;AWS_ACCOUNT_ID&gt;:role/&lt;IAM_ROLE_NAME&gt;</code></li>
+<li>Then, you need to add an annotation to that service account as described in these <a href="https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html">docs</a>. This annotation can be added to the Kubecost service account by setting <code>.Values.serviceAccount.annotations</code> in the helm chart to <code>eks.amazonaws.com/role-arn: arn:aws:iam::&lt;AWS_ACCOUNT_ID&gt;:role/&lt;IAM_ROLE_NAME&gt;</code></li>
 </ul>
 
 > Note: If you see the error: `User: ***/assumed-role/<role-name>/### is not authorized to perform: sts:AssumeRole on resource...`, you can add the following to your policy permissions to allow the role the correct permissions:


### PR DESCRIPTION
This PR replace some broken links related to IAM Role for Service Account present in the documentation by the current links from AWS documentation
Issue related https://github.com/kubecost/docs/issues/350