### PR TITLE
Unset request sizing v2 doc article ID

### DIFF
--- a/api-request-right-sizing-v2.md
+++ b/api-request-right-sizing-v2.md
@@ -57,4 +57,4 @@ target utilization parameters as described above.
 
 See [v1 docs](https://github.com/kubecost/docs/blob/main/api-request-right-sizing.md#savings-projection-methodology).
 
-<!--- {"article":"4407595919895","section":"4402829033367","permissiongroup":"1500001277122"} --->
+<!--- {"article":"","section":"4402829033367","permissiongroup":"1500001277122"} --->


### PR DESCRIPTION
This was accidentally copied from the v1 doc, meaning this doc never got published properly to our docs site because the article ID was also copied over and conflicted with the existing v1 doc.