### PR TITLE
Setup: GCP workload identity configuration

### DIFF
--- a/gcp-out-of-cluster.md
+++ b/gcp-out-of-cluster.md
@@ -17,7 +17,7 @@ GCP users should create [detailed billing export](https://cloud.google.com/billi
 
 ## Step 2:  Visit Kubecost setup page and provide configuration info
 
-If your Big Query dataset is in a different project than the one where Kubescost is installed, please see the section on [Cross-Project Service Accounts](#cross-project-service-account-configuration)
+If your Big Query dataset is in a different project than the one where Kubecost is installed, please see the section on [Cross-Project Service Accounts](#cross-project-service-account-configuration)
 
 Add a service account key to allocate out of cluster resources (e.g. storage buckets and managed databases) back to their Kubernetes owners. The service account needs the following:
 
@@ -37,35 +37,55 @@ gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compu
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.user
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.dataViewer
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.jobUser
+```
+
+Once you've created the GCP service account, you can connect it to Kubecost in one of two ways:
+
+### Connect using a service account key
+Create a service account key:
+```sh
 gcloud iam service-accounts keys create ./compute-viewer-kubecost-key.json --iam-account compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com
 ```
 
-You can then get your service account key to paste into the UI (be careful with this!):
-
+### Connect using Workload Identity federation
+Instead of manually setting up a service account key, you can use an [IAM policy binding](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to) to bind a Kubernetes service account to your GCP service account.
 ```sh
-cat compute-viewer-kubecost-key.json
+gcloud iam service-accounts add-iam-policy-binding compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member serviceAccount:compute-viewer-kubecost.svc.id.goog[NAMESPACE/KSA_NAME]
 ```
+where `NAMESPACE` and `KSA_NAME` are the namespace Kubecost is installed into and the name of the service account attributed to the Kubecost deployment 
 
-In Kubecost, sellect _Settings_ from the left navigation, and under External Cloud Cost Configuration (GCP), select _Update_, then follow the remaining instructions found at the "Add Key" link:
+Annotate the service account attributed to the Kubecost deployment:
+```sh
+kubectl annotate serviceaccount KSA_NAME --namespace NAMESPACE iam.gke.io/gcp-service-account=compute-viewer-kubecost@$PROJECT_ID.iam.gserviceaccount.com
+```
+where `NAMESPACE` and `KSA_NAME` are the namespace Kubecost is installed into and the name of the service account attributed to the Kubecost deployment
+
+Once the GCP service account has been connected, set up the remaining configuration parameters:
+
+### Configuring via the Kubecost UI
+In Kubecost, select _Settings_ from the left navigation, and under External Cloud Cost Configuration (GCP), select _Update_, then follow the remaining instructions found at the "Add Key" link:
 
 ![GCP out-of-cluster key entry](https://raw.githubusercontent.com/kubecost/docs/main/images/gcp-out-of-cluster-config-wo-shell.png)
 
+<a name="bq-name"></a>**BigQuery dataset** requires a BigQuery dataset prefix (e.g. billing_data) in addition to the BigQuery table name. A full example is `billing_data.gcp_billing_export_v1_018AIF_74KD1D_534A2`
 
-<a name="bq-name"></a>**BigQuery dataset** requires a BigQuery dataset prefix (e.g. billing_data) in addition to the BigQuery table name. A full example is `billing_data.gcp_billing_export_v1_018AIF_74KD1D_534A2`.
+<a name="bq-name"></a>**Service key** If you've created a service account key, copy the contents of the `compute-viewer-kubecost-key.json` file and paste them here (be careful with this!). If you've connected using Workload Identity federation, you should leave this box empty.
 
 ### Configuring using values.yaml (Recommended)
 
-It is recommended to provide the GCP details in the [values file](https://github.com/kubecost/cost-analyzer-helm-chart/blob/c10e9475b51612d36da8f04618174a98cc62f8fd/cost-analyzer/values.yaml#L572-L574)  to ensure they are retained during a upgrade or redeploy.
+It is recommended to provide the GCP details in the [values file](https://github.com/kubecost/cost-analyzer-helm-chart/blob/c10e9475b51612d36da8f04618174a98cc62f8fd/cost-analyzer/values.yaml#L572-L574) to ensure they are retained during an upgrade or redeploy.
 
-Then create a secret for the GCP service account key:
+* Set `.Values.kubecostProductConfigs.projectID = <GCP Project ID that contains the BigQuery Export>`
+* Set `.Values.kubecostProductConfigs.bigQueryBillingDataDataset = <DATASET.TABLE_NAME that contains the billing export>`
+
+If you've connected using Workload Identity federation, no additional setup is required.
+
+Otherwise, create a secret for the GCP service account key you've created:
 
 ```sh
 kubectl create secret generic gcp-secret -n kubecost --from-file=./compute-viewer-kubecost-key.json
 ```
-
-* Set `.Values.kubecostProductConfigs.projectID = <GCP Project ID that contains the BigQuery Export>`
-* Set `.Values.kubecostProductConfigs.gcpSecretName = <Name of the Kubernetes secret that contains the compute-viewer-kubecost-key.json file>`
-* Set `.Values.kubecostProductConfigs.bigQueryBillingDataDataset = <DATASET.TABLE_NAME that contains the billing export>`
+Then, set `.Values.kubecostProductConfigs.gcpSecretName = <Name of the Kubernetes secret that contains the compute-viewer-kubecost-key.json file>`
 
 > **Note**: When managing the service account key as a Kubernetes secret, the secret must reference the service account key json file, and that file must be named `compute-viewer-kubecost-key.json`.
 
@@ -106,7 +126,7 @@ export BIG_QUERY_PROJECT_ID=<Project ID where bigquery data is stored>
 export SERVICE_ACCOUNT_NAME=<Unique name for your service account>
 ```
 
-Once these values have been set, this script can be run and will create the service key needed for this configuration.
+Once these values have been set, this script can be run and will create the service account needed for this configuration.
 
 ```sh
 gcloud config set project KUBECOST_PROJECT_ID
@@ -115,10 +135,9 @@ gcloud projects add-iam-policy-binding $BIG_QUERY_PROJECT_ID --member serviceAcc
 gcloud projects add-iam-policy-binding $BIG_QUERY_PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$KUBECOST_PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.user
 gcloud projects add-iam-policy-binding $BIG_QUERY_PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$KUBECOST_PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.dataViewer
 gcloud projects add-iam-policy-binding $BIG_QUERY_PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$KUBECOST_PROJECT_ID.iam.gserviceaccount.com --role roles/bigquery.jobUser
-gcloud iam service-accounts keys create ./$SERVICE_ACCOUNT_NAME-key.json --iam-account $SERVICE_ACCOUNT_NAME@$KUBECOST_PROJECT_ID.iam.gserviceaccount.com
 ```
 
-Now that your service key is created, follow the normal configuration instructions.
+Now that your service account is created, follow the normal configuration instructions.
 
 Edit this doc on [GitHub](https://github.com/kubecost/docs/blob/main/gcp-out-of-cluster.md)
 

--- a/gcp-out-of-cluster.md
+++ b/gcp-out-of-cluster.md
@@ -48,6 +48,8 @@ gcloud iam service-accounts add-iam-policy-binding compute-viewer-kubecost@$PROJ
 ```
 where `NAMESPACE` and `KSA_NAME` are the namespace Kubecost is installed into and the name of the service account attributed to the Kubecost deployment
 
+You will also need to enable the [IAM Service Account Credentials API](https://cloud.google.com/iam/docs/reference/credentials/rest) in the gcloud project.
+
 ### Connect using a service account key
 Create a service account key:
 ```sh


### PR DESCRIPTION
Document steps to set up Workload Identity federation for GCP clusters. 

![image](https://user-images.githubusercontent.com/22826352/192646824-b6badc7f-eda8-40a8-85a4-d6d375f55a7a.png)
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/22826352/192759407-2a2f9efb-cbea-41ab-b346-f2390a15b20c.png">
![image](https://user-images.githubusercontent.com/22826352/192647420-02d7ec59-86fb-4cae-a411-be1fe602fb2e.png)
