### PR TITLE
Troubleshoot installation issue with PodSecurityPolicy on k8s clusters >= v1.25

### DIFF
--- a/troubleshoot-install.md
+++ b/troubleshoot-install.md
@@ -156,6 +156,36 @@ If this is true, you are likely to be hitting a CoreDNS routing issue. We recomm
 1. Go to <https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml#L13>
 2. Replace ```{{ $serviceName }}.{{ .Release.Namespace }}``` with ```localhost```
 
+## Issue: PodSecurityPolicy CRD is missing for `kubecost-grafana` and `kubecost-cost-analyzer-psp`
+
+PodSecurityPolicy has been [removed from Kubernetes v1.25](https://kubernetes.io/docs/concepts/security/pod-security-policy/). This will result in the following error during install.
+
+```bash
+$ helm install kubecost kubecost/cost-analyzer
+Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [
+    resource mapping not found for name: "kubecost-grafana" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1" ensure CRDs are installed first,
+    resource mapping not found for name: "kubecost-cost-analyzer-psp" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1" ensure CRDs are installed first
+]
+```
+
+To disable PodSecurityPolicy from Kubecost's Grafana Helm Chart:
+
+```bash
+# Clone the Helm chart
+$ git clone git@github.com:kubecost/cost-analyzer-helm-chart.git
+​
+# Update Grafana's configuration for PodSecurityPolicy
+# 
+# FILE:
+# ./cost-analyzer-helm-chart/cost-analyzer/charts/grafana/values.yaml
+# 
+# CONFIG:
+# .Values.rbac.pspEnabled: false
+​
+# Retry installing Kubecost, referencing the local Helm Chart
+$ helm upgrade -i kubecost ./cost-analyzer
+```
+
 ## Question: How can I run on Minikube?
 
 1. Edit nginx configmap ```kubectl edit cm nginx-conf -n kubecost```


### PR DESCRIPTION
Primary concern is that PodSecurityPolicy has been [removed from Kubernetes v1.25](https://kubernetes.io/docs/concepts/security/pod-security-policy/), however our Helm Chart still defaults to having it enabled for Grafana. I'm going to create a PR to cost-analyzer-helm chart so that we default to [`pspEnabled: false`](https://github.com/kubecost/cost-analyzer-helm-chart/blob/8fd5502925c28c56af38b0c4e66c4ec746761d50/cost-analyzer/charts/grafana/values.yaml#L3).

Despite that fact that I'll be fixing this issue soon, I believe this doc may still be useful to those who use our current/older Helm Charts on newer clusters.

Of course, let me know if anybody feels otherwise!