### PR TITLE
ContainerStats pipeline documentation

### DIFF
--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -1,0 +1,47 @@
+# The ContainerStats pipeline
+
+The ContainerStats pipeline builds statistical representations of individual
+containers' resource usage over time.  The pipeline is part of the `cost-model` container.
+
+## APIs
+
+### Request right-sizing recommendation v2
+
+The primary user of ContainerStats pipeline data is v2 of the request right-
+sizing recommendation API. ContainerStats data is used for quantile-based
+recommendations. [Docs](https://github.com/kubecost/docs/blob/main/api-request-right-sizing-v2.md)
+
+### Debugging
+
+There is an _unstable_, _unofficial_ API for introspecting pipeline data
+available at `/model/containerstats/quantiles`.
+
+## Behavior
+
+The pipeline builds 24 hour "windows" of data. It only builds complete windows,
+e.g. if now is `2003-08-23T08:30:00Z` the pipeline will only build up to the
+window from `2003-08-22T00:00:00Z` to `2003-08-23T00:00:00Z`.
+
+The pipeline will return an error response if a requested time range of data
+contains any windows (24 hour chunks) are "expected" (should be in the store)
+but not "available" (the pipeline has not yet built and loaded a complete set of
+data into the store).
+
+## Logs
+
+All ContainerStats-related log messages should contain `ContainerStats` or
+`ContainerStatsSet`. The pipeline logs a few things at INFO level to show that
+the pipeline is running successfully. Much greater detail is available at the
+DEBUG level. See [the official instructions](https://github.com/kubecost/cost-analyzer-helm-chart#adjusting-log-output) if you would like to learn how to change the log level.
+
+## Configuration
+
+The ContainerStats pipeline's behavior is controller by a few different
+environment variables.
+
+| Environment variable | Helm chart value | Description |
+|----------------------|------------------|-------------|
+| `CONTAINER_STATS_ENABLED` | `kubecostModel.containerStatsEnabled` | Enables the pipeline. |
+| Prometheus/Thanos configuration | | The pipeline inherits most of the existing Prometheus/Thanos configuration because it leverages the same client(s) used by the Asset and Allocation pipelines. Specific deviations will be mentioned. |
+| `ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES` | ??? | The pipeline will obey this, but may fail to initialize if this is set below the minimum value supported by the pipeline (10 minutes).
+| "Storage" configration | | The pipeline inherits most of the existing "store" configuration used by other pipelines like Asset and Allocation. This includes, but is not limited to: store duration, store type (file, federated, etc.), leader election, storage pathing, storage directory, bucket storage, and backup. |

--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -43,5 +43,5 @@ environment variables.
 |----------------------|------------------|-------------|
 | `CONTAINER_STATS_ENABLED` | `kubecostModel.containerStatsEnabled` | Enables the pipeline. |
 | Prometheus/Thanos configuration | | The pipeline inherits most of the existing Prometheus/Thanos configuration because it leverages the same client(s) used by the Asset and Allocation pipelines. Specific deviations will be mentioned. |
-| `ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES` | ??? | The pipeline will obey this, but may fail to initialize if this is set below the minimum value supported by the pipeline (10 minutes).
+| `ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES` | `kubecostModel.maxPrometheusQueryDurationMinutes` | The pipeline will obey this, but may fail to initialize if this is set below the minimum value supported by the pipeline (10 minutes).
 | "Storage" configration | | The pipeline inherits most of the existing "store" configuration used by other pipelines like Asset and Allocation. This includes, but is not limited to: store duration, store type (file, federated, etc.), leader election, storage pathing, storage directory, bucket storage, and backup. |

--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -25,8 +25,8 @@ e.g. if now is `2003-08-23T08:30:00Z`, the pipeline will only build up to the
 window from `2003-08-22T00:00:00Z` to `2003-08-23T00:00:00Z`.
 
 The pipeline will return an error response if a requested time range of data
-contains any windows (24 hour chunks) are expected (should be in the store)
-but not available (the pipeline has not yet built and loaded a complete set of
+contains any windows (24 hour chunks) are _expected_ (should be in the store)
+but not _available_ (the pipeline has not yet built and loaded a complete set of
 data into the store).
 
 ## Logs

--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -1,4 +1,4 @@
-# The ContainerStats pipeline
+# ContainerStats Pipeline
 
 The ContainerStats pipeline builds statistical representations of individual
 containers' resource usage over time.  The pipeline is part of the `cost-model` container.
@@ -9,7 +9,7 @@ containers' resource usage over time.  The pipeline is part of the `cost-model` 
 
 The primary user of ContainerStats pipeline data is v2 of the request right-
 sizing recommendation API. ContainerStats data is used for quantile-based
-recommendations. [Docs](https://github.com/kubecost/docs/blob/main/api-request-right-sizing-v2.md)
+recommendations. Review the doc for this feature [here](https://github.com/kubecost/docs/blob/main/api-request-right-sizing-v2.md).
 
 ### Debugging
 
@@ -19,12 +19,12 @@ available at `/model/containerstats/quantiles`.
 ## Behavior
 
 The pipeline builds 24 hour "windows" of data. It only builds complete windows,
-e.g. if now is `2003-08-23T08:30:00Z` the pipeline will only build up to the
+e.g. if now is `2003-08-23T08:30:00Z`, the pipeline will only build up to the
 window from `2003-08-22T00:00:00Z` to `2003-08-23T00:00:00Z`.
 
 The pipeline will return an error response if a requested time range of data
-contains any windows (24 hour chunks) are "expected" (should be in the store)
-but not "available" (the pipeline has not yet built and loaded a complete set of
+contains any windows (24 hour chunks) are expected (should be in the store)
+but not available (the pipeline has not yet built and loaded a complete set of
 data into the store).
 
 ## Logs
@@ -32,7 +32,7 @@ data into the store).
 All ContainerStats-related log messages should contain `ContainerStats` or
 `ContainerStatsSet`. The pipeline logs a few things at INFO level to show that
 the pipeline is running successfully. Much greater detail is available at the
-DEBUG level. See [the official instructions](https://github.com/kubecost/cost-analyzer-helm-chart#adjusting-log-output) if you would like to learn how to change the log level.
+DEBUG level. See [the official instructions](https://github.com/kubecost/cost-analyzer-helm-chart#adjusting-log-output) to learn how to change the log level.
 
 ## Configuration
 

--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -13,7 +13,7 @@ recommendations. Review the doc for this feature [here](https://github.com/kubec
 
 ### Debugging
 
-There is an for introspecting pipeline data available at
+There is an API for introspecting pipeline data available at
 `/model/containerstats/quantiles`. It does not have a stable schema and is not
 supported as an official product feature. It is only intended for limited
 debugging.

--- a/containerstats-pipeline.md
+++ b/containerstats-pipeline.md
@@ -13,8 +13,10 @@ recommendations. Review the doc for this feature [here](https://github.com/kubec
 
 ### Debugging
 
-There is an _unstable_, _unofficial_ API for introspecting pipeline data
-available at `/model/containerstats/quantiles`.
+There is an for introspecting pipeline data available at
+`/model/containerstats/quantiles`. It does not have a stable schema and is not
+supported as an official product feature. It is only intended for limited
+debugging.
 
 ## Behavior
 


### PR DESCRIPTION
Basic docs for the ContainerStats pipeline so the team (and users) have somewhere to go first if something looks awry.