### PR TITLE
add on-prem-pricing doc

### DIFF
--- a/node-pricing.md
+++ b/node-pricing.md
@@ -3,7 +3,7 @@ Node Pricing
 
 When explicit RAM, CPU or GPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU, GPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.
 
-These base RAM/CPU/GPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU/GPU costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.
+These base resource (RAM/CPU/GPU) prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of resource costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.
 
 For example, imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM GB price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU, remains 3x the price of a GB of RAM.
 

--- a/node-pricing.md
+++ b/node-pricing.md
@@ -1,4 +1,4 @@
-Node Pricing
+Calculating Node Pricing
 ============
 
 When explicit RAM, CPU or GPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU, GPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.

--- a/node-pricing.md
+++ b/node-pricing.md
@@ -1,9 +1,6 @@
 Node Pricing
 ============
 
-How do you determine RAM/CPU/GPU costs for a node when this data isn’t provided by a cloud provider?
----------------
-
 When explicit RAM, CPU or GPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU, GPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.
 
 These base RAM/CPU/GPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU/GPU costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.

--- a/node-pricing.md
+++ b/node-pricing.md
@@ -1,5 +1,5 @@
-On-Prem Pricing
-===============
+Node Pricing
+============
 
 How do you determine RAM/CPU/GPU costs for a node when this data isn’t provided by a cloud provider?
 ---------------
@@ -11,3 +11,5 @@ These base RAM/CPU/GPU prices are normalized to ensure the sum of each component
 For example, imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM GB price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU, remains 3x the price of a GB of RAM.
 
     NodeHourlyCost = NORMALIZED_GPU_PRICE * # of GPUs + NORMALIZED_CPU_PRICE * # of CPUs + NORMALIZED_RAM_PRICE * # of RAM GB
+
+[Code Reference](https://github.com/opencost/opencost/blob/v1.98.0/pkg/costmodel/costmodel.go#L933)

--- a/on-prem-pricing.md
+++ b/on-prem-pricing.md
@@ -1,0 +1,13 @@
+On-Prem Pricing
+===============
+
+How do you determine RAM/CPU/GPU costs for a node when this data isn’t provided by a cloud provider?
+---------------
+
+When explicit RAM, CPU or GPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU, GPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.
+
+These base RAM/CPU/GPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU/GPU costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.
+
+As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU remain 3x the price of a Gb of RAM.
+
+    NodeHourlyCost = NORMALIZED_GPU_PRICE * # of GPUs + NORMALIZED_CPU_PRICE * # of CPUs + NORMALIZED_RAM_PRICE * # of RAM Gb

--- a/on-prem-pricing.md
+++ b/on-prem-pricing.md
@@ -8,6 +8,6 @@ When explicit RAM, CPU or GPU prices are not provided by your cloud provider, th
 
 These base RAM/CPU/GPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU/GPU costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.
 
-As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU remain 3x the price of a Gb of RAM.
+For example, imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM GB price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU, remains 3x the price of a GB of RAM.
 
-    NodeHourlyCost = NORMALIZED_GPU_PRICE * # of GPUs + NORMALIZED_CPU_PRICE * # of CPUs + NORMALIZED_RAM_PRICE * # of RAM Gb
+    NodeHourlyCost = NORMALIZED_GPU_PRICE * # of GPUs + NORMALIZED_CPU_PRICE * # of CPUs + NORMALIZED_RAM_PRICE * # of RAM GB


### PR DESCRIPTION
taken from [old cost-model readme](https://github.com/opencost/opencost/blob/3f0185bea59e8a617b7c41e86a05a820bc07977d/README.md#how-do-you-determine-ramcpugpu-costs-for-a-node-when-this-data-isnt-provided-by-a-cloud-provider)