### PR TITLE
add note for hourly windows

### DIFF
--- a/api-request-right-sizing-v2.md
+++ b/api-request-right-sizing-v2.md
@@ -26,7 +26,7 @@ http://<kubecost-address>/model/savings/requestSizingV2
 | `qRAM` | float in the range (0, 1] | Like `qCPU`, but for RAM recommendations.
 | `targetCPUUtilization` | float in the range (0,1] | An ratio of headroom on the base recommended CPU request. If the base recommendation is 100 mCPU and this parameter is `0.8`, the recommended CPU request will be `100 / 0.8 = 125` mCPU. Defaults to `0.7`. Inputs that fail to parse (see https://pkg.go.dev/strconv#ParseFloat) will default to `0.7`.|
 | `targetRAMUtilization` | float in the range (0,1] | Calculated like CPU. |
-| `window` | string | Required parameter. Duration of time over which to calculate usage. Supports days before the current time in the following format: `3d`. See the [Allocation API documentation](https://github.com/kubecost/docs/blob/main/allocation.md#querying) for more a more detailed explanation of valid inputs to `window`. |
+| `window` | string | Required parameter. Duration of time over which to calculate usage. Supports days before the current time in the following format: `3d`. Note: Hourly windows are not currently supported. See the [Allocation API documentation](https://github.com/kubecost/docs/blob/main/allocation.md#querying) for more a more detailed explanation of valid inputs to `window`. |
 | `filter` | string | A filter to reduce the set of workloads for which recommendations will be calculated. See [V2 Filters](https://github.com/kubecost/docs/blob/main/filteres-v2.md) for syntax. V1 filters are also supported, please see v1 API documentation. |
 
 


### PR DESCRIPTION
I tested myself and this still seems to hold true. Any hourly windows that can't be satisfied by a daily window return:

> Recommending requests from data: CPU algorithm set to max but no max data is available

Doesn't Work:
- https://demo.kubecost.io/model/savings/requestSizingV2?window=1h
- https://demo.kubecost.io/model/savings/requestSizingV2?window=3h
- https://demo.kubecost.io/model/savings/requestSizingV2?window=12h

Works (same data):
- http://demo.kubecost.io/model/savings/requestSizingV2?window=1d
- http://demo.kubecost.io/model/savings/requestSizingV2?window=24h
- http://demo.kubecost.io/model/savings/requestSizingV2?window=36h

Closes https://github.com/kubecost/support/issues/26. 