### PR TITLE
Refer to OpenCost rather than the cost-model

### DIFF
--- a/install.md
+++ b/install.md
@@ -83,7 +83,7 @@ For larger teams and companies with more complex infrastructure, you need the ri
 
 * You can run [Helm Template](https://helm.sh/docs/helm/helm\_template/) against the [Kubecost Helm Chart](https://github.com/kubecost/cost-analyzer-helm-chart/) to generate local YAML output. This requires extra effort when compared to directly installing the Helm Chart but is more flexible than deploying static YAML.
 * You can install via [flat manifest](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/README.md#manifest). This install path provides less flexibility for managing your deployment and has several product limitations, e.g. Thanos is not easily enabled.
-* Lastly, you can deploy the open source project directly as a Pod. This install path provides a subset of free functionality and is available [here](https://github.com/kubecost/cost-model/blob/master/deploying-as-a-pod.md). Specifically, this install path deploys the underlying cost allocation model without the same UI or access to enterprise functionality, e.g. SAML support.
+* Lastly, you can deploy the open source OpenCost project directly as a Pod. This install path provides a subset of free functionality and is available [here](https://www.opencost.io/docs/install). Specifically, this install path deploys the underlying cost allocation model without the same UI or access to enterprise functionality, e.g. SAML support.
 
 
 


### PR DESCRIPTION
Updated the link to point to OpenCost install docs rather than old cost-model link