### PR TITLE
Update allocation.md to account for querying the cost-model Pod directly

### DIFF
--- a/allocation.md
+++ b/allocation.md
@@ -6,7 +6,7 @@ The Allocation API is the preferred way to query for costs and resources allocat
 http://<kubecost>/model/allocation
 ```
 
-> **Note**: Throughout, we use `localhost:9090` as the default Kubecost URL, but your Kubecost instance may be exposed by a service or ingress. To reach Kubecost at port 9090, run: `kubectl port-forward deployment/kubecost-cost-analyzer -n kubecost 9090`
+> **Note**: Throughout, we use `localhost:9090` as the default Kubecost URL, but your Kubecost instance may be exposed by a service or ingress. To reach Kubecost at port 9090, run: `kubectl port-forward deployment/kubecost-cost-analyzer -n kubecost 9090`. When querying the cost-model container directly (ex. localhost:9003), the `/model` part of the URI should be removed.
 
 ## Quick start
 


### PR DESCRIPTION
Had to dig around for why `/model/allocation/compute` does not work when querying the cost-model container.

Only the  `/allocation` handler is defined:

```go
a.Router.GET("/allocation/compute", a.ComputeAllocationHandler)
```

An NGINX location block is defined for `/model/` with a [proxy_pass](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) defined:

```
location /model/ {
    ...
    proxy_pass http://model/;
}
```

>If the proxy_pass directive is specified with a URI, then when a request is passed to the server, the part of a [normalized](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) request URI matching the location is replaced by a URI specified in the directive...