### PR TITLE
Adjust NavBar for Network Costs Docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -47,7 +47,7 @@
 * [Advanced Configuration](install-and-configure/advanced-configuration/README.md)
   * [Add Key](add-key.md)
   * [Enabling Annotation Emission](annotations.md)
-  * [Network Traffic Cost Allocation](network-allocation.md)
+  * [Network Cost Configuration](network-costs-configuration.md)
   * [User Management - SSO/SAML/RBAC](user-management.md)
   * [Multi-Cluster Options](multi-cluster.md)
   * [Federated Clusters](federated-clusters.md)
@@ -107,6 +107,7 @@
 
 * [Kubecost Core Architecture Overview](architecture.md)
 * [Kubecost Cloud Architecture Overview](kubecost-cloud-architecture.md)
+* [Network Traffic Cost Allocation](network-allocation.md)
 * [Open Source](open-source-deps.md)
 * [Security and Data Protection](security.md)
 * [Ports](ports.md)

--- a/network-allocation.md
+++ b/network-allocation.md
@@ -3,11 +3,12 @@
 This document describes how Kubecost calculates network costs.
 
 ![network-costs screenshot](images/network-cost-overview.png)
+
 ## Network Cost Calculation Methodology
 
 Kubecost uses best-effort to allocate network transfer costs to the workloads generating those costs. The level of accuracy has several factors described below.
 
-There are two primary factors when determining how network costs are calculated: [Cloud Integration](./cloud-integration.md) and the existence of the [network costs daemonset](./network-allocation.md).
+There are two primary factors when determining how network costs are calculated: [Cloud Integration](./cloud-integration.md) and the existence of the [network costs daemonset](./network-costs-configuration.md).
 
 ### Base Functionality
 


### PR DESCRIPTION
This is a follow up to PR https://github.com/kubecost/docs/pull/478

Add the "Network Cost Configuration" doc into Advanced Configuration since it describes how to set up the daemonset. Move the "Network Traffic Cost Allocation" doc into Architecture since it describes how the allocation logic roughly works.