### PR TITLE
kubecost cloud docs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -185,7 +185,7 @@ redirects:
     hc/en-us/articles/4413635957271-Installing-Kubecost-with-Rafay: rafay.md
     hc/en-us/articles/4423256582551-Kubecost-Secondary-Clusters: secondary-clusters.md
     hc/en-us/articles/4425080011671-Ports: ports.md
-    hc/en-us/articles/4425132038167-Installing-Agent-for-Hosted-Kubecost-Alpha-: agent.md
+    hc/en-us/articles/4425132038167-Installing-Agent-for-Hosted-Kubecost: agent.md
     hc/en-us/articles/4425134686743-User-Metrics: user-metrics.md
     hc/en-us/articles/4442565953943-Getting-Started: code-contribution.md
     hc/en-us/articles/5699259004311-Grafana-Cloud-Integration-for-Kubecost: grafana-cloud-integration.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -65,7 +65,7 @@
 
 * [OpenCost Product Comparison](opencost-product-comparison.md)
 * [User Metrics](user-metrics.md)
-* [Installing Agent for Kubecost Cloud (Alpha)](agent.md)
+* [Installing Agent for Kubecost Cloud](agent.md)
 * [Tuning Resource Consumption](resource-consumption.md)
 * [Calculating Node Pricing](node-pricing.md)
 

--- a/agent.md
+++ b/agent.md
@@ -1,4 +1,4 @@
-# Installing Agent for Kubecost Cloud (limited availability)
+# Installing Agent for Kubecost Cloud
 
 The _kubecost-agent_ is a lightweight Kubecost exporter that sends metrics to Kubecost Cloud. In order to install the _kubecost-agent_, you will need a specific key provided by Kubecost.
 
@@ -29,6 +29,7 @@ helm install kubecost-agent \
 
 Optionally, add the Network Costs Daemonset:
 * All Providers: `--set networkCosts.enabled=true`
+
 And one of the following (if applicable):
 * AWS `--set networkCosts.config.services.amazon-web-services=true`
 * Azure `--set networkCosts.config.services.azure-cloud-services=true`


### PR DESCRIPTION
Add missing line break in list
Consistent wording for limited access vs alpha. 

Please verify TOC updates are consistent?