### PR TITLE
adding three new network costs field returned in allocation response

### DIFF
--- a/allocation.md
+++ b/allocation.md
@@ -77,6 +77,9 @@ cpuEfficiency | Ratio of `cpuCoreUsageAverage`-to-`cpuCoreRequestAverage`, meant
 gpuHours | Cumulative GPU-hours allocated.
 gpuCost | Cumulative cost of allocated GPU-hours.
 networkCost | Cumulative cost of network usage.
+networkCrossZoneCost | Cumulative cost of Cross-zone network egress usage.
+networkCrossRegionCost | Cumulative cost of Cross-region network egress usage.
+networkInternetCost | Cumulative cost of internet egress usage.
 pvBytes | Average number of bytes of PersistentVolumes allocated while running.
 pvByteHours | Cumulative PersistentVolume byte-hours allocated.
 pvCost | Cumulative cost of allocated PersistentVolume byte-hours.


### PR DESCRIPTION
Adding the three new fields returned in allocation response related to opencost change [PR 1594](https://github.com/opencost/opencost/pull/1594) 

networkCrossZoneCost represents network egress usage cost related to cross zone usage.
networkCrossRegionCost  represents network egress usage cost related to cross region usage.
networkInternetCost  represents network egress usage cost related to  internet usage.

Suggestion to merge after PR opened by Brett https://github.com/kubecost/docs/pull/501