### PR TITLE
Document /logs/level endpoint

### DIFF
--- a/troubleshoot-install.md
+++ b/troubleshoot-install.md
@@ -73,6 +73,15 @@ For example, to set the log level to `debug`, add the following flag to the Helm
   * A nice human readable output 
   * `2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")`
 
+### Temporarily setting log level
+To temporarily set the log level (does not persist between Pod restarts, Helm deployments, etc.), you can send a POST request to `/logs/level` with one of the valid log levels. Here's an example:
+
+```sh
+curl -X POST \
+    'http://localhost:9090/model/logs/level' \
+    -d '{"level": "debug"}'
+```
+
 ## Issue: No persistent volumes available for this claim and/or no storage class is set
 
 Your clusters need a default storage class for the Kubecost and Prometheus persistent volumes to be successfully attached.

--- a/troubleshoot-install.md
+++ b/troubleshoot-install.md
@@ -73,8 +73,8 @@ For example, to set the log level to `debug`, add the following flag to the Helm
   * A nice human readable output 
   * `2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")`
 
-### Temporarily setting log level
-To temporarily set the log level (does not persist between Pod restarts, Helm deployments, etc.), you can send a POST request to `/logs/level` with one of the valid log levels. Here's an example:
+### Temporarily set log level
+To temporarily set the log level without restarting the Pod, you can send a POST request to `/logs/level` with one of the valid log levels. This does not persist between Pod restarts, Helm deployments, etc. Here's an example:
 
 ```sh
 curl -X POST \

--- a/troubleshoot-install.md
+++ b/troubleshoot-install.md
@@ -82,6 +82,8 @@ curl -X POST \
     -d '{"level": "debug"}'
 ```
 
+A GET request can be sent to the same endpoint to retrieve the current log level.
+
 ## Issue: No persistent volumes available for this claim and/or no storage class is set
 
 Your clusters need a default storage class for the Kubecost and Prometheus persistent volumes to be successfully attached.


### PR DESCRIPTION
Thanks to Steven's amazing work on https://github.com/kubecost/kubecost-cost-model/issues/932 we can now set log level without restarting Kubecost. @saweber does this look right?

@kubecost/support-engineers @kubecost/solutions-engineers I suspect you'll find this very useful in debugging work in v1.100+ of Kubecost.