### PR TITLE
Note why uncontrolled pods cannot be supported in Kubescaler/Continuous request right sizing

### DIFF
--- a/continuous-request-sizing.md
+++ b/continuous-request-sizing.md
@@ -30,6 +30,13 @@ Notable Helm values:
 | ---------- | ----------- | ---------- |
 | `clusterController.kubescaler.resizeAllDefault` | If true, Kubescaler will switch to default-enabled for all workloads unless they are annotated with `request.autoscaling.kubecost.com/enabled=false`. This is recommended for low-stakes clusters where you want to prioritize workload efficiency without reworking deployment specs for all workloads. | `true` |
 
+### Supported workload types
+Kubescaler supports:
+- Deployments
+
+Kubescaler cannot support:
+- "Uncontrolled" Pods. See https://github.com/kubernetes/kubernetes/issues/24913
+
 ### Example
 
 ``` sh

--- a/continuous-request-sizing.md
+++ b/continuous-request-sizing.md
@@ -35,7 +35,7 @@ Kubescaler supports:
 - Deployments
 
 Kubescaler cannot support:
-- "Uncontrolled" Pods. See https://github.com/kubernetes/kubernetes/issues/24913
+- "Uncontrolled" Pods. Learn more [here](https://github.com/kubernetes/kubernetes/issues/24913).
 
 ### Example
 


### PR DESCRIPTION
There will be another update to this doc before the release of 1.100 that increases the size of the "supports" section, just want to open this PR so I don't forget the link.