### PR TITLE
Kubecost v1.100 will require Helmv3.1+

### DIFF
--- a/alibaba-install.md
+++ b/alibaba-install.md
@@ -2,7 +2,7 @@
 
 ## Helm install Kubecost
 
-Kubecost installation is exactly same as other cloud providers with Helm 3:
+Kubecost installation is exactly same as other cloud providers with Helm v3.1+:
 
 ` helm install kubecost/cost-analyzer -n kubecost -f values.yaml`
 

--- a/install.md
+++ b/install.md
@@ -77,13 +77,13 @@ For larger teams and companies with more complex infrastructure, you need the ri
 
 ## Alternative installation methods
 
-* You can also install directly with the [Kubecost Helm Chart](https://github.com/kubecost/cost-analyzer-helm-chart/) with Helm 3 using the following commands. This provides the same functionality as the step above but doesn't generate a product token for managing tiers or upgrade trials.
+* You can also install directly with the [Kubecost Helm Chart](https://github.com/kubecost/cost-analyzer-helm-chart/) with Helm v3.1+ using the following commands. This provides the same functionality as the step above but doesn't generate a product token for managing tiers or upgrade trials.
 
-```
- helm repo add kubecost https://kubecost.github.io/cost-analyzer/
- helm upgrade --install kubecost kubecost/cost-analyzer --namespace kubecost --create-namespace
+```bash
+$ helm repo add kubecost https://kubecost.github.io/cost-analyzer/
+$ helm upgrade --install kubecost kubecost/cost-analyzer --namespace kubecost --create-namespace
 ```
 
-* You can run [Helm Template](https://helm.sh/docs/helm/helm\_template/) against the [Kubecost Helm Chart](https://github.com/kubecost/cost-analyzer-helm-chart/) to generate local YAML output. This requires extra effort when compared to directly installing the Helm Chart but is more flexible than deploying static YAML.
+* You can run [Helm Template](https://helm.sh/docs/helm/helm_template/) against the [Kubecost Helm Chart](https://github.com/kubecost/cost-analyzer-helm-chart/) to generate local YAML output. This requires extra effort when compared to directly installing the Helm Chart but is more flexible than deploying static YAML.
 * You can install via [flat manifest](https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/README.md#manifest). This install path provides less flexibility for managing your deployment and has several product limitations, e.g. Thanos is not easily enabled.
 * Lastly, you can deploy the open source OpenCost project directly as a Pod. This install path provides a subset of free functionality and is available [here](https://www.opencost.io/docs/install). Specifically, this install path deploys the underlying cost allocation model without the same UI or access to enterprise functionality, e.g. SAML support.


### PR DESCRIPTION
Specifically, because v1.100 uses the `lookup` function [here](https://github.com/kubecost/cost-analyzer-helm-chart/blob/v1.100/cost-analyzer/templates/NOTES.txt#L4-L8), which only works in Helm v3.1+.