### PR TITLE
Add section for disabling metrics in ksm docs

### DIFF
--- a/ksm-metrics.md
+++ b/ksm-metrics.md
@@ -50,6 +50,20 @@ kubecostMetrics:
   emitKsmV1Metrics: false
 ```
 
+## Disabling Individual Metrics
+
+While also not recommended, it is possible to disable individual metrics emitted by Kubecost if a more fine-grained approach is required. This can be done by setting the related [Helm chart parameter](https://github.com/kubecost/cost-analyzer-helm-chart/blob/f9a8f3326a540e1b0ece714c52f100fa085bf0b8/cost-analyzer/values.yaml#L928-L929):
+```yaml
+kubecostProductConfigs:
+  ...
+  metricsConfigs:
+    disabledMetrics:
+      - <metric-to-be-disabled>
+      - <metric-to-be-disabled>
+      etc.
+```
+Note that this can diable metrics that Kubecost requires to function, and may lead to unexpected behavior.
+
 ## External KSM deployments resulting in duplicated metrics
 
 If your Prometheus deployment is scraping both Kubecost *and* an external KSM deployment outside of Kubecost, there will be duplicated KSM metrics.

--- a/ksm-metrics.md
+++ b/ksm-metrics.md
@@ -52,7 +52,10 @@ kubecostMetrics:
 
 ## Disabling Individual Metrics
 
-While also not recommended, it is possible to disable individual metrics emitted by Kubecost if a more fine-grained approach is required. This can be done by setting the related [Helm chart parameter](https://github.com/kubecost/cost-analyzer-helm-chart/blob/f9a8f3326a540e1b0ece714c52f100fa085bf0b8/cost-analyzer/values.yaml#L928-L929):
+> **Warning**: Disabling individual metrics is not recommended, as disabling metrics required by Kubecost to function may lead to unexpected behavior.
+
+It is possible to disable individual metrics emitted by Kubecost if a more fine-grained approach is required. This can be done by setting the related [Helm chart parameter](https://github.com/kubecost/cost-analyzer-helm-chart/blob/f9a8f3326a540e1b0ece714c52f100fa085bf0b8/cost-analyzer/values.yaml#L928-L929):
+
 ```yaml
 kubecostProductConfigs:
   ...
@@ -62,7 +65,6 @@ kubecostProductConfigs:
       - <metric-to-be-disabled>
       etc.
 ```
-Note that this can diable metrics that Kubecost requires to function, and may lead to unexpected behavior.
 
 ## External KSM deployments resulting in duplicated metrics
 


### PR DESCRIPTION
Adds a section to KSM metrics detailing the method/helm config for disabling individual metrics. Thought it best to include here, as metrics duplication seems to be the chief use-case for this feature.

Ref: https://github.com/opencost/opencost/issues/1571