### PR TITLE
Efficiency example correction

### DIFF
--- a/efficiency-idle.md
+++ b/efficiency-idle.md
@@ -14,7 +14,7 @@ Pod resource efficiency is defined as the resource utilization versus the resour
 > *CPU Usage = rate(container\_cpu\_usage\_seconds\_total) over the time window* \
 > *RAM Usage = avg(container\_memory\_working\_set\_bytes) over the time window*
 
-For example, if a pod is requesting 2CPU and 1GB, using 500mCPU and 500MB, CPU on the node costs $10/CPU, and RAM on the node costs $1/GB, we have ((0.5/2) \* 20 + (0.5/1) \* 1) / (20 + 1) = 5.5 / 21 = 26%
+For example, if a pod is requesting 2CPU and 1GB, using 500mCPU and 500MB, CPU on the node costs $10/CPU, and RAM on the node costs $1/GB, we have ((0.5/2) \* 10 + (0.5/1) \* 1) / (10 + 1) = 3 / 11 = 27%
 
 ## Idle
 


### PR DESCRIPTION
I'm not 100% sure, but I believe there is an error in this example. Currently, the example replaces `CPU Cost = CPU price * CPU Requested` and that means that `CPU Requested` gets canceled with  `CPU Usage / CPU Requested`. I believe the correct way would be to just replace `CPU Cost` with `$10/CPU` ([This calculator](https://docs.google.com/spreadsheets/d/15CL2YrJHIcQyDMHu3vB3jXdTdcqEntawmy5T3zsVZ_g/edit#gid=0) linked in another section of the documentation does exactly that). Same with the memory but in this case it doesn't make a difference because both cost and requested are 1.

Opening a PR to discuss if this would be correct or not. Also opened a discussion in slack [here](https://kubecost.slack.com/archives/CE76NJE6S/p1676649764702879).