### PR TITLE
docs: fix typo in global.prometheus.fqdn param value example

### DIFF
--- a/custom-prom.md
+++ b/custom-prom.md
@@ -45,7 +45,7 @@ helm upgrade --install kubecost \
     helm upgrade --install kubecost \
       --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
       --namespace kubecost --create-namespace \
-      --set global.prometheus.fqdn=http://<prometheus-server-service-name>:<port>.<prometheus-server-namespace>.svc \
+      --set global.prometheus.fqdn=http://<prometheus-server-service-name>.<prometheus-server-namespace>.svc:<port> \
       --set global.prometheus.enabled=false
     ```
 


### PR DESCRIPTION
* Fix typo in `global.prometheus.fqdn` parameter  (move <port> to the end) inside of `custom-prod.md` doc.