### PR TITLE
Remove storage.md from file tree

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -51,7 +51,6 @@
     * [Amazon Managed Service for Prometheus](aws-amp-integration.md)
     * [Grafana Cloud Integration for Kubecost](grafana-cloud-integration.md)
     * [Google Cloud Managed Service for Prometheus](gcp-gmp-integration.md)
-  * [Cost Analyzer Persistent Volume](storage.md)
 * [Additional Configuration](install-and-configure/advanced-configuration/README.md)
   * [Add Key](add-key.md)
   * [Enabling Annotation Emission](annotations.md)


### PR DESCRIPTION
This document was pertinent back in Kubecost ~v1.67, but likely no longer applies to a large portion of existing users