### PR TITLE
Manually updates Allocation API doc to correct unintentional indents

### DIFF
--- a/allocation.md
+++ b/allocation.md
@@ -4,23 +4,7 @@
 
 {% swagger method="get" path="/allocation" baseUrl="http://<your-kubecost-address>/model" summary="Allocation API" %}
 {% swagger-description %}
-The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like 
-
-`namespace`
-
-, 
-
-`controller`
-
-, and 
-
-`label`
-
-. Data is served from one of 
-
-[Kubecost's ETL pipelines](cost-model-deprecated.md#caching-overview)
-
-.
+The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like `namespace`, `controller`, and `label`. Data is served from one of [Kubecost's ETL pipelines](cost-model-deprecated.md#caching-overview).
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" type="string" required="true" %}
@@ -30,193 +14,95 @@ Duration of time over which to query. Accepts words like `today`, `week`, `month
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Field by which to aggregate the results. Accepts:
-
-`cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like
-
-`namespace,label:app`.
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
-If `true`, sum the entire range of sets into a single set. Default value is
-
-`false`.
+If `true`, sum the entire range of sets into a single set. Default value is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idle" type="boolean" required="false" %}
-If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. (See [special types of allocation](https://docs.kubecost.com/apis/apis-overview/allocation#special-types-of-allocation).) Default is
-
-`true.`
+If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. (See [special types of allocation](https://docs.kubecost.com/apis/apis-overview/allocation#special-types-of-allocation).) Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="external" type="boolean" required="false" %}
-If 
-
-`true`
-
-, include 
-
-[external costs](https://docs.kubecost.com/#advanced-configuration)
-
- in each allocation. Default is 
-
-`false`
-
-.
+If `true`, include [external costs](https://docs.kubecost.com/#advanced-configuration)in each allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterClusters" type="string" required="false" %}
-Comma-separated list of clusters to match; e.g.
-
-`cluster-one,cluster-two`
-
-will return results from only those two clusters.
+Comma-separated list of clusters to match; e.g. `cluster-one,cluster-two` will return results from only those two clusters.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNodes" type="string" required="false" %}
-Comma-separated list of nodes to match; e.g.
-
-`node-one,node-two`
-
-will return results from only those two nodes.
+Comma-separated list of nodes to match; e.g. `node-one,node-two` will return results from only those two nodes.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to match; e.g.
-
-`namespace-one,namespace-two`
-
-will return results from only those two namespaces.
+Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` will return results from only those two namespaces.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterControllerKinds" type="string" required="false" %}
-Comma-separated list of controller kinds to match; e.g.
-
-`deployment,job`
-
-will return results with only those two controller kinds.
+Comma-separated list of controller kinds to match; e.g. `deployment,job` will return results with only those two controller kinds.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterControllers" type="string" required="false" %}
-Comma-separated list of controllers to match; e.g. 
-
-`deployment-one,statefulset-two`
-
- will return results from only those two controllers.
+Comma-separated list of controllers to match; e.g. `deployment-one,statefulset-two` will return results from only those two controllers.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterPods" type="string" required="false" %}
-Comma-separated list of pods to match; e.g. `pod-one,pod-two`
-
-will return results from only those two pods.
+Comma-separated list of pods to match; e.g. `pod-one,pod-two` will return results from only those two pods.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterAnnotations" type="string" required="false" %}
-Comma-separated list of annotations to match; e.g. `name:annotation-one,name:annotation-two`
-
-will return results with either of those two annotation key-value-pairs.
+Comma-separated list of annotations to match; e.g. `name:annotation-one,name:annotation-two` will return results with either of those two annotation key-value-pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterLabels" type="string" required="false" %}
-Comma-separated list of annotations to match; e.g. `app:cost-analyzer, app:prometheus`
-
-will return results with either of those two label key-value-pairs.
+Comma-separated list of annotations to match; e.g. `app:cost-analyzer, app:prometheus` will return results with either of those two label key-value-pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterServices" type="string" required="false" %}
-Comma-separated list of services to match; e.g. `frontend-one,frontend-two`
-
-will return results with either of those two services.
+Comma-separated list of services to match; e.g. `frontend-one,frontend-two` will return results with either of those two services.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="format" type="string" required="false" %}
-Set to `csv` to download an accumulated version of the allocation results in CSV format. Set to `pdf`
-
-to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
+Set to `csv` to download an accumulated version of the allocation results in CSV format. Set to `pdf` to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
-If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is
-
-`false`.
+If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="splitIdle" type="boolean" required="false" %}
-If `true`, and `shareIdle == false`, Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is
-
-`false`.
+If `true`, and `shareIdle == false`, Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
-If 
-
-`true`
-
-, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is 
-
-`false`
-
-.
+If `true`, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
-If 
-
-`true`
-
-, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost categories cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is 
-
-`true`
-
-.
+If `true`, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost categories cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareTenancyCosts" type="boolean" required="false" %}
-If 
-
-`true`
-
-, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. As of v1.93.0 both cluster management and attached volumes are shared by cluster. Default is 
-
-`true`
-
-.
+If `true`, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. As of v1.93.0 both cluster management and attached volumes are shared by cluster. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to share; e.g.
-
-`kube-system, kubecost`
-
-will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
+Comma-separated list of namespaces to share; e.g. `kube-system, kubecost` will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareLabels" type="string" required="false" %}
-Comma-separated list of labels to share; e.g. 
-
-`env:staging, app:test`
-
- will share the costs of those two label values with the remaining non-idle, unshared allocations.
+Comma-separated list of labels to share; e.g. `env:staging, app:test` will share the costs of those two label values with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareCost" type="float" required="false" %}
-Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. 
-
-`30.42`
-
- ($1.00/day == $30.42/month) for the query 
-
-`yesterday`
-
- (1 day) will split and distribute exactly $1.00 across the allocations. Default is 
-
-`0.0.`
+Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. `30.42` ($1.00/day = $30.42/month) for the query `yesterday` (1 day) will split and distribute exactly $1.00 across the allocations. Default is `0.0.`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareSplit" type="string" required="false" %}
-Determines how to split shared costs among non-idle, unshared allocations. By default, the split will be `weighted`; i.e. proportional to the cost of the allocation, relative to the total. The other option is `even`; i.e. each allocation gets an equal portion of the shared cost. Default is
-
-`weighted`.
+Determines how to split shared costs among non-idle, unshared allocations. By default, the split will be `weighted`; i.e. proportional to the cost of the allocation, relative to the total. The other option is `even`; i.e. each allocation gets an equal portion of the shared cost. Default is `weighted`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}

--- a/assets-api.md
+++ b/assets-api.md
@@ -18,7 +18,7 @@ When set to `false`, this endpoint returns daily time series data vs cumulative 
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="disableAdjustments" type="boolean" required="false" %}
-When set to `true`, zeros out all adjustments from cloud provider reconciliation, which would otherwise change the totalCost. Default value is`false`.
+When set to `true`, zeros out all adjustments from cloud provider reconciliation, which would otherwise change the totalCost. Default value is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="format" type="string" required="false" %}

--- a/assets-api.md
+++ b/assets-api.md
@@ -38,7 +38,7 @@ Filter results by cluster ID, which is generated from `cluster_id` provided duri
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterLabels" type="string" required="false" %}
-Filter results by cloud label or cloud tag. For example, appending `&labels=deployment:kubecost-cost-analyzer` only returns assets with label`deployment=kubecost-cost-analyzer`. Note that subparameter `:` symbols are required to denote `<labelKey>:<labelValue>` pairs.
+Filter results by cloud label or cloud tag. For example, appending `&labels=deployment:kubecost-cost-analyzer` only returns assets with label `deployment=kubecost-cost-analyzer`. Note that subparameter `:` symbols are required to denote `<labelKey>:<labelValue>` pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNames" type="string" required="false" %}

--- a/assets-api.md
+++ b/assets-api.md
@@ -14,77 +14,31 @@ Used to consolidate cost model data. Supported aggregation types are cluster and
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
-When set to 
-
-`false`
-
-, this endpoint returns daily time series data vs cumulative data. Default value is 
-
-`false`
-
-.
+When set to `false`, this endpoint returns daily time series data vs cumulative data. Default value is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="disableAdjustments" type="boolean" required="false" %}
-When set to `true`, zeros out all adjustments from cloud provider reconciliation, which would otherwise change the totalCost. Default value is
-
-`false`.
+When set to `true`, zeros out all adjustments from cloud provider reconciliation, which would otherwise change the totalCost. Default value is`false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="format" type="string" required="false" %}
-When set to 
-
-`csv`
-
-, will download an accumulated version of the asset results in CSV format. By default, results will be in JSON format.
+When set to `csv`, will download an accumulated version of the asset results in CSV format. By default, results will be in JSON format.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterAccounts" type="string" required="false" %}
-Filter results by cloud account.
-
-_Requires cloud configuration._
+Filter results by cloud account. _Requires cloud configuration._
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterCategories" type="string" required="false" %}
-Filter results by asset category, such as 
-
-`Network`
-
-, 
-
-`Management`
-
-, 
-
-`Compute`
-
-, 
-
-`Storage`
-
-, or 
-
-`Other`
-
-.
+Filter results by asset category, such as `Network`, `Management`, `Compute`, `Storage`, or `Other`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterClusters" type="string" required="false" %}
-Filter results by cluster ID, which is generated from `cluster_id`
-
-provided during installation.
+Filter results by cluster ID, which is generated from `cluster_id` provided during installation.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterLabels" type="string" required="false" %}
-Filter results by cloud label or cloud tag. For example, appending
-
-`&labels=deployment:kubecost-cost-analyzer`
-
-only returns assets with label
-
-`deployment=kubecost-cost-analyzer`. Note that subparameter `:` symbols are required to denote
-
-`<labelKey>:<labelValue>` pairs.
+Filter results by cloud label or cloud tag. For example, appending `&labels=deployment:kubecost-cost-analyzer` only returns assets with label`deployment=kubecost-cost-analyzer`. Note that subparameter `:` symbols are required to denote `<labelKey>:<labelValue>` pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNames" type="string" required="false" %}
@@ -92,35 +46,23 @@ Filter results by asset name.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterProjects" type="string" required="false" %}
-Filter results by cloud project ID.
-
-_Requires cloud configuration._
+Filter results by cloud project ID. _Requires cloud configuration._
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterProviders" type="string" required="false" %}
-Filter results by provider. For example, appending
-
-`&filterProviders=GCP`
-
-only returns assets belonging to provider `GCP`. _Requires cloud configuration._
+Filter results by provider. For example, appending `&filterProviders=GCP` only returns assets belonging to provider `GCP`. _Requires cloud configuration._
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterProviderIDs" type="string" required="false" %}
-Filter results by provider ID individual to each cloud asset. For examples, go to the Assets page, select Breakdown by Item, and see the Provider ID column.
-
-_Requires cloud configuration._
+Filter results by provider ID individual to each cloud asset. For examples, go to the Assets page, select Breakdown by Item, and see the Provider ID column. _Requires cloud configuration._
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterServices" type="string" required="false" %}
-Filter results by service. Examples include
-
-`Cloud Storage`, `Kubernetes`, `BigQuery`.
+Filter results by service. Examples include `Cloud Storage`, `Kubernetes`, `BigQuery`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterTypes" type="string" required="false" %}
-Filter results by asset type. Examples include `Cloud`, `ClusterManagement`,
-
-`Node`, `LoadBalancer`, and `Disk`.
+Filter results by asset type. Examples include `Cloud`, `ClusterManagement`, `Node`, `LoadBalancer`, and `Disk`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}


### PR DESCRIPTION
Based on an existing docs issue, I am manually reverting double indents in this doc which seems to be a symptom of GitBook being unable to register changes when syncing with GitHub. Seeking a more permanent resolution from GB.