### PR TITLE
xlink cloud metrics and clean up wording

### DIFF
--- a/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
+++ b/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
@@ -150,19 +150,20 @@ Kubecost uses Net Cost.
 
 </details>
 
-## Kubernetes percent by CSP
+## Kubernetes Clusters
 
-Whether or not a specific resource belongs as part of a Kubernetes cluster is not something that is made available in any of the billing integrations, and is not something that can be determined with 100% accuracy in all situations. To populate this field at the item level, Kubecost uses heuristics based on the existence of labels, or the service that the resource originates from. These heuristics are only capable of detecting resources that belong to the managed Kubernetes offerings from each CSP.\
+To calculate the `K8 Utilization`, Kubecost first must determine if a resources is part of a Kubernetes cluster, or an unrelated cloud service.
+
+If a tag or label in the list below is present on the billing export, Kubecost will consider those costs part of the `K8 Utilization` calculation. This will not always be 100% accurate in all situations.\
 
 
 <details>
 
 <summary>AWS</summary>
 
-The CUR only has labels that have been enabled for it, each as its own individual column rather than in a JSON object of key-value pairs. Because of this, the efficacy of this heuristic is limited by the labels that it targets being enabled.
+In AWS, Kubecost will identify the line item in the bill as a Kubernetes resource if one of the following tags is present in the CUR.
 
-If `line_item_product_code` is `AmazonEKS`, or one of the following label keys is present:
-
+* `AmazonEKS`
 * `resource_tags_aws_eks_cluster_name`
 * `resource_tags_user_eks_cluster_name`
 * `resource_tags_user_alpha_eksctl_io_cluster_name`

--- a/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
+++ b/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
@@ -161,9 +161,12 @@ If a tag or label in the list below is present on the billing export, Kubecost w
 
 <summary>AWS</summary>
 
-In AWS, Kubecost will identify the line item in the bill as a Kubernetes resource if one of the following tags is present in the CUR.
+In AWS, Kubecost will identify the line item in the bill as a Kubernetes resource if
 
-* `AmazonEKS`
+* `line_item_product_code` is `AmazonEKS`
+
+or one of the following label keys is present:
+
 * `resource_tags_aws_eks_cluster_name`
 * `resource_tags_user_eks_cluster_name`
 * `resource_tags_user_alpha_eksctl_io_cluster_name`

--- a/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
+++ b/apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md
@@ -152,7 +152,7 @@ Kubecost uses Net Cost.
 
 ## Kubernetes Clusters
 
-To calculate the `K8 Utilization`, Kubecost first must determine if a resources is part of a Kubernetes cluster, or an unrelated cloud service.
+To calculate the `K8 Utilization`, Kubecost first must determine if a resources is part of a Kubernetes cluster or not.
 
 If a tag or label in the list below is present on the billing export, Kubecost will consider those costs part of the `K8 Utilization` calculation. This will not always be 100% accurate in all situations.\
 

--- a/using-kubecost/getting-started/clusters-dashboard.md
+++ b/using-kubecost/getting-started/clusters-dashboard.md
@@ -38,6 +38,8 @@ Clusters are primarily distinguished into three categories:
 * Clusters not monitored by Kubecost (yellow circle next to cluster name)
 * Inactive clusters (gray circle next to cluster name)
 
+For detail on how Kubecost identifies clusters, see [Cloud Cost Metrics](https://docs.kubecost.com/apis/apis-overview/cloud-cost-api/cloud-cost-metrics#kubernetes-clusters).
+
 Monitored clusters are those that have cost metrics which will appear within your other Monitoring dashboards, like Allocations and Assets. Unmonitored clusters are clusters whose existence is determined from cloud integration, but haven't been added to Kubecost. Inactive clusters are clusters Kubecost once monitored, but haven't reported data over a certain period of time. This time period is three hours for Thanos-enabled clusters, and one hour for non-Thanos clusters.
 
 Efficiency and Last Seen metrics are only provided for monitored clusters.


### PR DESCRIPTION
The list of tags is coming up frequently- adding link from cluster detail page.

The cloud-cost-metrics is a bit wordy, this is a first attempt to simpilfy.

