### PR TITLE
Fix capitalization of CloudCost config IsIncludeList

### DIFF
--- a/using-kubecost/getting-started/cloud-cost-explorer.md
+++ b/using-kubecost/getting-started/cloud-cost-explorer.md
@@ -22,7 +22,7 @@ kubecostModel:
 Enabling Cloud Cost is required. Optional parameters include:
 
 * `labelList.labels`: Comma separated list of labels; empty string indicates that the list is disabled
-* `labelList.isIncludeList`: If true, label list is a white list; if false, it is a black list
+* `labelList.IsIncludeList`: If true, label list is a white list; if false, it is a black list
 * `topNItems`: number of sampled "top items" to collect per day
 
 While Cloud Cost is enabled, it is recommended to disable Cloud Usage, which is more memory-intensive.

--- a/using-kubecost/getting-started/cloud-costs-explorer.md
+++ b/using-kubecost/getting-started/cloud-costs-explorer.md
@@ -17,7 +17,7 @@ kubecostModel:
   cloudCost:
      enabled: true
      labelList:
-       isIncludeList: false
+       IsIncludeList: false
        # format labels as comma separated string (ex. "label1,label2,label3")
        labels: ""
      topNItems: 1000
@@ -26,7 +26,7 @@ kubecostModel:
 Enabling Cloud Cost is required. Optional parameters include:
 
 * `labelList.labels`: Comma-separated list of labels; empty string indicates that the list is disabled
-* `labelList.isIncludeList`: If true, label list is a white list; if false, it is a black list
+* `labelList.IsIncludeList`: If true, label list is a white list; if false, it is a black list
 * `topNItems`: number of sampled "top items" to collect per day
 
 While Cloud Cost is enabled, it is recommended to disable Cloud Usage, which is more memory-intensive.

--- a/using-kubecost/getting-started/clusters-dashboard.md
+++ b/using-kubecost/getting-started/clusters-dashboard.md
@@ -24,7 +24,7 @@ kubecostModel:
   cloudCost:
      enabled: true
      labelList:
-       isIncludeList: false
+       IsIncludeList: false
        # format labels as comma separated string (ex. "label1,label2,label3")
        labels: ""
      topNItems: 1000


### PR DESCRIPTION
The correct capitalization is shown at the following locations:
- https://github.com/kubecost/cost-analyzer-helm-chart/blob/27045c7e5fab79fd39ffcc397f4c1d6b109843b2/cost-analyzer/values.yaml#L440-L448
- https://github.com/kubecost/cost-analyzer-helm-chart/blob/27045c7e5fab79fd39ffcc397f4c1d6b109843b2/cost-analyzer/templates/cost-analyzer-deployment-template.yaml#L837