### PR TITLE
add bug and enhancement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,36 @@
+name: "Bug Report"
+description: Report a bug in the Kubecost documentation.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please tell us about the bug.
+  - type: input
+    id: link
+    attributes:
+      label: Page link
+      description: >-
+        Please provide the page link where the bug can be found.
+      # placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description
+      description: Describe the problem.
+      # placeholder: Tell us what you see!
+      # value: "asdf"
+    validations:
+      required: true
+  - type: textarea
+    id: bug-expectations
+    attributes:
+      label: Expected behavior
+      description: What would you like to see?
+      # placeholder: Tell us what you see!
+      # value: "asdf"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,18 @@
+name: "Enhancement"
+description: Recommend an enhancement to the Kubecost documentation.
+title: "[Enhancement] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        What would you like to see added to the documentation?
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what enhancement you'd like to see.
+      # placeholder: Tell us what you see!
+      # value: "asdf"
+    validations:
+      required: true


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

Partially satisfies #701

This PR adds bug and enhancement issue templates based on GitHub forms.