### PR TITLE
Updates Container Request Right Sizing API doc to remove GitBook glitched indents

### DIFF
--- a/api-request-right-sizing-v2.md
+++ b/api-request-right-sizing-v2.md
@@ -2,63 +2,35 @@
 
 {% swagger method="get" path="savings/requestSizingV2" baseUrl="http://<kubecost-address>/model/" summary="Container Request Right Sizing Recommendation API (V2)" %}
 {% swagger-description %}
-The container request right sizing recommendation API provides recommendations for
-
-[container resource requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-
-based on configurable parameters and estimates the savings from implementing those recommendations on a per-container, per-controller level. Of course, if the cluster-level resources stay static then you will likely not enjoy real savings from applying these recommendations until you reduce your cluster resources. Instead, your idle allocation will increase.
+The container request right sizing recommendation API provides recommendations for [container resource requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) based on configurable parameters and estimates the savings from implementing those recommendations on a per-container, per-controller level. Of course, if the cluster-level resources stay static then you will likely not enjoy real savings from applying these recommendations until you reduce your cluster resources. Instead, your idle allocation will increase.
 {% endswagger-description %}
 
 {% swagger-parameter in="query" name="algorithmCPU" type="string" required="false" %}
-The algorithm to be used to calculate CPU recommendations based on historical CPU usage data. Options are `max` and `quantile`. Max recommendations are based on the maximum-observed usage in `window`. Quantile recommendations are based on a quantile of observed usage in `window` (requires the `qCPU` parameter to set the desired quantile). Defaults to `max`. To use the `quantile` algorithm, the
-
-[ContainerStats Pipeline](containerstats-pipeline.md)
-
-must be enabled.
+The algorithm to be used to calculate CPU recommendations based on historical CPU usage data. Options are `max` and `quantile`. Max recommendations are based on the maximum-observed usage in `window`. Quantile recommendations are based on a quantile of observed usage in `window` (requires the `qCPU` parameter to set the desired quantile). Defaults to `max`. To use the `quantile` algorithm, the [ContainerStats Pipeline](containerstats-pipeline.md) must be enabled.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="algorithmRAM" type="string" required="false" %}
-Like 
-
-`algorithmCPU`
-
-, but for RAM recommendations.
+Like `algorithmCPU`, but for RAM recommendations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="qCPU" type="float in the range (0, 1]" required="false" %}
-The desired quantile to base CPU recommendations on. Only used if
-
-`algorithmCPU=quantile`. **Note**: a quantile of `0.95`is the same as a 95th percentile.
+The desired quantile to base CPU recommendations on. Only used if `algorithmCPU=quantile`. **Note**: a quantile of `0.95`is the same as a 95th percentile.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="qRAM" type="float in the range (0, 1]" required="false" %}
-Like 
-
-`qCPU`
-
-, but for RAM recommendations.
+Like `qCPU`, but for RAM recommendations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="targetCPUUtilization" type="float in the range (0, 1]" required="false" %}
-A ratio of headroom on the base recommended CPU request. If the base recommendation is 100 mCPU and this parameter is `0.8`, the recommended CPU request will be
-
-`100 / 0.8 = 125` mCPU. Defaults to `0.7`. Inputs that fail to parse (see
-
-[Go docs here](https://pkg.go.dev/strconv#ParseFloat)) will default to `0.7`.
+A ratio of headroom on the base recommended CPU request. If the base recommendation is 100 mCPU and this parameter is `0.8`, the recommended CPU request will be `100 / 0.8 = 125` mCPU. Defaults to `0.7`. Inputs that fail to parse (see [Go docs here](https://pkg.go.dev/strconv#ParseFloat)) will default to `0.7`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="targetRAMUtilization" type="float in the range (0, 1]" required="false" %}
-Calculated like
-
-`targetCPUUtilization`.
+Calculated like `targetCPUUtilization`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="minRecCPUMillicores" type="float" %}
-Lower bound, in millicores, of the CPU recommendation. Defaults to 10. \
-\
-Please be careful when modifying below 10 for the following reason.
-
-K8s currently recommends a maximum of 110 pods per node. A 10m minimum recommendation allows close to that (if all nodes are single core) while also being a round number.
+Lower bound, in millicores, of the CPU recommendation. Defaults to 10. Be careful when modifying below 10 for the following reason. Kubernetes currently recommends a maximum of 110 pods per node. A 10m minimum recommendation allows close to that (if all nodes are single core) while also being a round number.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="minRecRAMBytes" type="float" %}
@@ -68,29 +40,19 @@ Lower bound, in bytes, of the RAM recommendation. Defaults to 20MiB (20 * 1024 *
 {% swagger-parameter in="query" name="window" required="true" type="string" %}
 Required parameter. Duration of time over which to calculate usage. Supports days before the current time in the following format:
 
-`3d`. **Note**: Hourly windows are not currently supported. **Note**: It's recommended to provide a window greater than
-
-`2d`. See the
-
-[Allocation API documentation](allocation.md)
-
-for more a more detailed explanation of valid inputs to
-
-`window`.
+`3d`. **Note**: Hourly windows are not currently supported. **Note**: It's recommended to provide a window greater than `2d`. See the [Allocation API documentation](allocation.md) for more a more detailed explanation of valid inputs to `window`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="filter" type="string" required="false" %}
-A filter to reduce the set of workloads for which recommendations will be calculated. See [Filter parameters](filters-api.md)
-
-for syntax. V1 filters are also supported.
+A filter to reduce the set of workloads for which recommendations will be calculated. See [Filter parameters](filters-api.md) for syntax. V1 filters are also supported.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="sortBy" type="string" %}
-Column to sort the response by. Defaults to "totalSavings". Options are "totalSavings", "currentEfficiency", "cpuRecommended", "cpuLatest", "memoryRecommended", and "memoryLatest".
+Column to sort the response by. Defaults to `totalSavings`. Options are `totalSavings`, `currentEfficiency`, `cpuRecommended`, `cpuLatest`, `memoryRecommended`, and `memoryLatest`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="sortByOrder" type="string" %}
-Order to sort by. Defaults to "descending". Options are "descending" and "ascending".
+Order to sort by. Default value `descending`. Options are `descending` and `ascending`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}

--- a/api-request-right-sizing-v2.md
+++ b/api-request-right-sizing-v2.md
@@ -14,7 +14,7 @@ Like `algorithmCPU`, but for RAM recommendations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="qCPU" type="float in the range (0, 1]" required="false" %}
-The desired quantile to base CPU recommendations on. Only used if `algorithmCPU=quantile`. **Note**: a quantile of `0.95`is the same as a 95th percentile.
+The desired quantile to base CPU recommendations on. Only used if `algorithmCPU=quantile`. **Note**: a quantile of `0.95` is the same as a 95th percentile.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="qRAM" type="float in the range (0, 1]" required="false" %}
@@ -52,7 +52,7 @@ Column to sort the response by. Defaults to `totalSavings`. Options are `totalSa
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="sortByOrder" type="string" %}
-Order to sort by. Default value `descending`. Options are `descending` and `ascending`.
+Order to sort by. Defaults to `descending`. Options are `descending` and `ascending`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}


### PR DESCRIPTION
Chip, I'm assigning you as a reviewer so you can see this repeated problem we've had with our API docs.

A while back I restructured our APIs using GitBook's API cell feature to better organize parameters, example outputs, and other details about our APIs. However, one repeated error I keep seeing in these docs is that it unnecessarily indents when it detects inline code or other style elements. This requires manual changes to fix it in the source file. I have raised the issue to GitBook, who sees the changes being made against the source code (even though we are not manually doing it), and they assume we're doing it on purpose even though this is clearly a bug. In case you see this behavior in our API doc, just wanted to let you know why it's happening, and to let me know.

This PR just updates this one doc, but I was hoping to get your thoughts on this before I continue making changes to a few other affected docs.