### PR TITLE
replace Linh's links with upstream

### DIFF
--- a/aws-eks-cost-monitoring.md
+++ b/aws-eks-cost-monitoring.md
@@ -179,7 +179,7 @@ To install Kubecost on Amazon EKS cluster on AWS Graviton2 (ARM-based processor)
 helm upgrade -i kubecost \
 oci://public.ecr.aws/kubecost/cost-analyzer --version <$VERSION> \
 --namespace kubecost --create-namespace \
--f https://raw.githubusercontent.com/linhlam-kc/cost-analyzer-helm-chart/aws-eks/cost-analyzer/values-eks-cost-monitoring.yaml \
+-f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/develop/cost-analyzer/values-eks-cost-monitoring.yaml \
 --set prometheus.configmapReload.prometheus.image.repository=jimmidyson/configmap-reload \
 --set prometheus.configmapReload.prometheus.image.tag=v0.7.1
 ```
@@ -247,7 +247,7 @@ To install Kubecost on an EKS-A cluster on AWS Graviton2 (ARM-based processor), 
 helm upgrade -i kubecost \
 oci://public.ecr.aws/kubecost/cost-analyzer --version <$VERSION> \
 --namespace kubecost --create-namespace \
--f https://raw.githubusercontent.com/linhlam-kc/cost-analyzer-helm-chart/aws-eks/cost-analyzer/values-eks-cost-monitoring.yaml \
+-f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/develop/cost-analyzer/values-eks-cost-monitoring.yaml \
 --set prometheus.configmapReload.prometheus.image.repository=jimmidyson/configmap-reload \
 --set prometheus.configmapReload.prometheus.image.tag=v0.7.1
 ```


### PR DESCRIPTION
Replaces links to files from a personal repo with the canonical versions in the Helm chart's repo.