### PR TITLE
Resolves more broken formatting in API documentation

### DIFF
--- a/allocation.md
+++ b/allocation.md
@@ -6,379 +6,107 @@ Throughout our API documentation, we use `localhost:9090` as the default Kubecos
 
 {% swagger method="get" path="/allocation" baseUrl="http://<your-kubecost-address>/model" summary="Allocation API" %}
 {% swagger-description %}
-The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like 
-
-`namespace`
-
-, 
-
-`controller`
-
-, and 
-
-`label`
-
-. Data is served from one of 
-
-[Kubecost's ETL pipelines](cost-model-deprecated.md#caching-overview)
-
-.
+The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like `namespace`, `controller`, and `label`. Data is served from one of [Kubecost's ETL pipelines](cost-model-deprecated.md#caching-overview).
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" type="string" required="true" %}
-Duration of time over which to query. Accepts words like 
-
-`today`
-
-, 
-
-`week`
-
-, 
-
-`month`
-
-, 
-
-`yesterday`
-
-, 
-
-`lastweek`
-
-, 
-
-`lastmonth`
-
-; durations like 
-
-`30m`
-
-, 
-
-`12h`
-
-, 
-
-`7d`
-
-; comma-separated RFC3339 date pairs like
-
-`2021-01-02T15:04:05Z,2021-02-02T15:04:05Z`
-
-; comma-separated Unix timestamp (seconds) pairs like 
-
-`1578002645,1580681045`
-
-.
+Duration of time over which to query. Accepts words like `today`, `week`, `month`, `yesterday`, `lastweek`, `lastmonth`; durations like `30m`, `12h`, `7d`; comma-separated RFC3339 date pairs like `2021-01-02T15:04:05Z,2021-02-02T15:04:05Z`; comma-separated Unix timestamp (seconds) pairs like `1578002645,1580681045`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Field by which to aggregate the results. Accepts: 
-
-`cluster`
-
-, 
-
-`namespace`
-
-, 
-
-`controllerKind`
-
-, 
-
-`controller`
-
-, 
-
-`service`
-
-, 
-
-`node`
-
-, 
-
-`pod`
-
-, 
-
-`label:<name>`
-
-, and 
-
-`annotation:<name>`
-
-. Also accepts comma-separated lists for multi-aggregation, like 
-
-`namespace,label:app`
-
-.
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
-If 
-
-`true`
-
-, sum the entire range of sets into a single set. Default value is 
-
-`false`
-
-.
+If `true`, sum the entire range of sets into a single set. Default value is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idle" type="boolean" required="false" %}
-If 
-
-`true`
-
-, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. (See 
-
-[special types of allocation](https://docs.kubecost.com/apis/apis-overview/allocation#special-types-of-allocation)
-
-.) Default is 
-
-`true.`
+If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. (See [special types of allocation](https://docs.kubecost.com/apis/apis-overview/allocation#special-types-of-allocation).) Default is `true.`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="external" type="boolean" required="false" %}
-If 
-
-`true`
-
-, include 
-
-[external costs](https://docs.kubecost.com/#advanced-configuration)
-
- in each allocation. Default is 
-
-`false`
-
-.
+If `true`, include [external costs](https://docs.kubecost.com/#advanced-configuration) in each allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterClusters" type="string" required="false" %}
-Comma-separated list of clusters to match; e.g. 
-
-`cluster-one,cluster-two`
-
- will return results from only those two clusters.
+Comma-separated list of clusters to match; e.g. `cluster-one,cluster-two` will return results from only those two clusters.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNodes" type="string" required="false" %}
-Comma-separated list of nodes to match; e.g. 
-
-`node-one,node-two`
-
- will return results from only those two nodes.
+Comma-separated list of nodes to match; e.g. `node-one,node-two` will return results from only those two nodes.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to match; e.g. 
-
-`namespace-one,namespace-two`
-
- will return results from only those two namespaces.
+Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` will return results from only those two namespaces.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterControllerKinds" type="string" required="false" %}
-Comma-separated list of controller kinds to match; e.g. 
-
-`deployment, job`
-
- will return results with only those two controller kinds.
+Comma-separated list of controller kinds to match; e.g. `deployment, job` will return results with only those two controller kinds.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterControllers" type="string" required="false" %}
-Comma-separated list of controllers to match; e.g. 
-
-`deployment-one,statefulset-two`
-
- will return results from only those two controllers.
+Comma-separated list of controllers to match; e.g. `deployment-one,statefulset-two` will return results from only those two controllers.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterPods" type="string" required="false" %}
-Comma-separated list of pods to match; e.g. 
-
-`pod-one,pod-two`
-
- will return results from only those two pods.
+Comma-separated list of pods to match; e.g. `pod-one,pod-two` will return results from only those two pods.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterAnnotations" type="string" required="false" %}
-Comma-separated list of annotations to match; e.g. 
-
-`name:annotation-one,name:annotation-two`
-
- will return results with either of those two annotation key-value-pairs.
+Comma-separated list of annotations to match; e.g. `name:annotation-one,name:annotation-two` will return results with either of those two annotation key-value-pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterLabels" type="string" required="false" %}
-Comma-separated list of annotations to match; e.g. 
-
-`app:cost-analyzer, app:prometheus`
-
- will return results with either of those two label key-value-pairs.
+Comma-separated list of annotations to match; e.g. `app:cost-analyzer, app:prometheus` will return results with either of those two label key-value-pairs.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterServices" type="string" required="false" %}
-Comma-separated list of services to match; e.g. 
-
-`frontend-one,frontend-two`
-
- will return results with either of those two services.
+Comma-separated list of services to match; e.g. `frontend-one,frontend-two` will return results with either of those two services.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="format" type="string" required="false" %}
-Set to 
-
-`csv`
-
- to download an accumulated version of the allocation results in CSV format. Set to 
-
-`pdf`
-
- to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
+Set to `csv` to download an accumulated version of the allocation results in CSV format. Set to `pdf` to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
-If 
-
-`true`
-
-, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is 
-
-`false`
-
-.
+If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="splitIdle" type="boolean" required="false" %}
-If 
-
-`true`
-
-, and 
-
-`shareIdle == false`
-
-, Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "
-
-_idle_
-
-" allocation. Default is 
-
-`false`
-
-.
+If `true`, and `shareIdle == false`, Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
-If 
-
-`true`
-
-, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is 
-
-`false`
-
-.
+If `true`, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
-If 
-
-`true`
-
-, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost category's cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is 
-
-`true`
-
-.
+If `true`, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost category's cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareTenancyCosts" type="boolean" required="false" %}
-If 
-
-`true`
-
-, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. As of v1.93.0 both cluster management and attached volumes are shared by cluster. Default is 
-
-`true`
-
-.
+If `true`, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. As of v1.93.0 both cluster management and attached volumes are shared by cluster. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to share; e.g. 
-
-`kube-system, kubecost`
-
- will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
+Comma-separated list of namespaces to share; e.g. `kube-system, kubecost` will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareLabels" type="string" required="false" %}
-Comma-separated list of labels to share; e.g. 
-
-`env:staging, app:test`
-
- will share the costs of those two label values with the remaining non-idle, unshared allocations.
+Comma-separated list of labels to share; e.g. `env:staging, app:test` will share the costs of those two label values with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareCost" type="float" required="false" %}
-Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. 
-
-`30.42`
-
- ($1.00/day == $30.42/month) for the query 
-
-`yesterday`
-
- (1 day) will split and distribute exactly $1.00 across the allocations. Default is 
-
-`0.0.`
+Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. `30.42` ($1.00/day == $30.42/month) for the query `yesterday` (1 day) will split and distribute exactly $1.00 across the allocations. Default is `0.0.`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareSplit" type="string" required="false" %}
-Determines how to split shared costs among non-idle, unshared allocations. By default, the split will be 
-
-`weighted`
-
-; i.e. proportional to the cost of the allocation, relative to the total. The other option is 
-
-`even`
-
-; i.e. each allocation gets an equal portion of the shared cost. Default is 
-
-`weighted`
-
-.
+Determines how to split shared costs among non-idle, unshared allocations. By default, the split will be `weighted`; i.e. proportional to the cost of the allocation, relative to the total. The other option is `even`; i.e. each allocation gets an equal portion of the shared cost. Default is `weighted`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="step" type="string" %}
-Duration of each individual data metric across the 
-
-`window`
-
-. Accepts 
-
-`1h`
-
-, 
-
-`1d`
-
-, or 
-
-`1w`
-
-. If left blank, defaults to longest step duration based on level of granularity of data represented by 
-
-`window`
-
-.
+Duration of each individual data metric across the `window`. Accepts `1h`, `1d`, or `1w`. If left blank, defaults to longest step duration based on level of granularity of data represented by `window`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}
@@ -773,57 +501,15 @@ for details. Default is
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="step" type="string" required="false" %}
-Duration of a single allocation set. If unspecified, this defaults to the
-
-`window`, so that you receive exactly one set for the entire window. If specified, it works chronologically backward, querying in durations of `step` until the full window is covered.
+Duration of a single allocation set. If unspecified, this defaults to the `window`, so that you receive exactly one set for the entire window. If specified, it works chronologically backward, querying in durations of `step` until the full window is covered.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Field by which to aggregate the results. Accepts:
-
-`cluster`
-
-,
-
-`namespace`
-
-,
-
-`controllerKind`
-
-,
-
-`controller`
-
-,
-
-`service`
-
-,
-
-`label:<name>`
-
-, and
-
-`annotation:<name>`
-
-. Also accepts comma-separated lists for multi-aggregation, like
-
-`namespace,label:app`
-
-.
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`,`controllerKind`, `controller`, `service`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
-If
-
-`true`
-
-, sum the entire range of sets into a single set. Default value is
-
-`false`
-
-.
+If `true`, sum the entire range of sets into a single set. Default value is `false`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}
@@ -981,8 +667,6 @@ Here, we provide theoretical error bounds for different resolution values given 
 * \-1.00, 10.00 means that the result could be as high as 1000% error (e.g. 30s pod being counted for 5m) or the pod could be missed altogether, i.e. -100% error.
 
 <table><thead><tr><th width="129" align="right">resolution</th><th align="center">30s pod</th><th align="center">5m pod</th><th align="center">1h pod</th><th align="center">1d pod</th><th align="center">7d pod</th></tr></thead><tbody><tr><td align="right">1m</td><td align="center">-1.00, 2.00</td><td align="center">0.80, 1.00</td><td align="center">0.98, 1.00</td><td align="center">1.00, 1.00</td><td align="center">1.00, 1.00</td></tr><tr><td align="right">2m</td><td align="center">-1.00, 4.00</td><td align="center">0.80, 1.20</td><td align="center">0.97, 1.00</td><td align="center">1.00, 1.00</td><td align="center">1.00, 1.00</td></tr><tr><td align="right">5m</td><td align="center">-1.00, 10.00</td><td align="center">-1.00, 1.00</td><td align="center">0.92, 1.00</td><td align="center">1.00, 1.00</td><td align="center">1.00, 1.00</td></tr><tr><td align="right">10m</td><td align="center">-1.00, 20.00</td><td align="center">-1.00, 2.00</td><td align="center">0.83, 1.00</td><td align="center">0.99, 1.00</td><td align="center">1.00, 1.00</td></tr><tr><td align="right">30m</td><td align="center">-1.00, 60.00</td><td align="center">-1.00, 6.00</td><td align="center">0.50, 1.00</td><td align="center">0.98, 1.00</td><td align="center">1.00, 1.00</td></tr><tr><td align="right">60m</td><td align="center">-1.00, 120.00</td><td align="center">-1.00, 12.00</td><td align="center">-1.00, 1.00</td><td align="center">0.96, 1.00</td><td align="center">0.99, 1.00</td></tr></tbody></table>
-
-
 
 ## Troubleshooting
 

--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -6,195 +6,59 @@ Analyzes change in total cost of allocations relative to a previous window of th
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" required="true" type="string" %}
-Duration of time over which to query. Compares cost usage of window to cost usage window of equal size directly preceding it. Accepts all standard Kubecost window formats (See our doc on using
-
-[the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)
-
-).
+Duration of time over which to query. Compares cost usage of window to cost usage window of equal size directly preceding it. Accepts all standard Kubecost window formats (See our doc on using [the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)).
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Field by which to aggregate the results. Accepts:
-
-`cluster`
-
-,
-
-`namespace`
-
-,
-
-`controllerKind`
-
-,
-
-`controller`
-
-,
-
-`service`
-
-,
-
-`node`
-
-,
-
-`pod`
-
-,
-
-`label:<name>`
-
-, and
-
-`annotation:<name>`
-
-. Also accepts comma-separated lists for multi-aggregation, like
-
-`namespace,label:app`
-
-.
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="external" type="string" required="false" %}
-If
-
-`true`
-
-, include external costs in each allocation. Default is
-
-`false`
-
-.
+If `true`, include external costs in each allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idle" type="boolean" required="false" %}
-If
-
-`true`
-
-, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. Default is
-
-`true.`
+If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to match; e.g.
-
-`namespace-one,namespace-two`
-
-will return results from only those two namespaces.
+Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` will return results from only those two namespaces.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
-If
-
-`true`
-
-, and
-
-`shareIdle == false`
-
-Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is
-
-`false`
-
-.
+If `true`, and `shareIdle == false`, idle allocations are created on a per cluster or per node basis rather than being aggregated into a single idle allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to share; e.g.
-
-`kube-system, kubecost`
-
-will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
+Comma-separated list of namespaces to share; e.g. `kube-system, kubecost` will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareLabels" type="string" required="false" %}
-Comma-separated list of labels to share; e.g.
-
-`env:staging, app:test`
-
-will share the costs of those two label values with the remaining non-idle, unshared allocations.
+Comma-separated list of labels to share; e.g. `env:staging, app:test` will share the costs of those two label values with the remaining non-idle, unshared allocations.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareCost" type="float" required="false" %}
-Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g.
-
-`30.42`
-
-($1.00/day == $30.42/month) for the query
-
-`yesterday`
-
-(1 day) will split and distribute exactly $1.00 across the allocations. Default is
-
-`0.0.`
+Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. `30.42` ($1.00/day == $30.42/month) for the query `yesterday` (1 day) will split and distribute exactly $1.00 across the allocations. Default is `0.0.`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareTenancyCosts" type="boolean" required="false" %}
-If
-
-`true`
-
-, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. Both cluster management and attached volumes are shared by cluster. Default is
-
-`true`
-
-.
+If `true`, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. Both cluster management and attached volumes are shared by cluster. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
-If
-
-`true`
-
-, idle allocations are created on a per node basis, which will result in different values when shared and more idle allocations when split. Default is
-
-`false`
-
-.
+If `true`, idle allocations are created on a per node basis, which will result in different values when shared and more idle allocations when split. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="splitIdle" type="boolean" required="false" %}
-If
-
-`true`
-
-, and
-
-`shareIdle == false`
-
-Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is
-
-`false`
-
-.
+If `true`, and `shareIdle == false`, idle allocations are created on a per cluster or per node basis rather than being aggregated into a single idle allocation. Default is `false`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
-If
-
-`true`
-
-, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost categories cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is
-
-`true`
-
-.
+If `true`, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost categories cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="step" type="string" required="false" %}
-Duration of a single allocation set. If unspecified, this defaults to the
-
-`window`
-
-, so that you receive exactly one set for the entire window. If specified, it works chronologically backward, querying in durations of
-
-`step`
-
-until the full window is covered.
+Duration of a single allocation set. If unspecified, this defaults to the `window`, so that you receive exactly one set for the entire window. If specified, it works chronologically backward, querying in durations of `step` until the full window is covered.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}

--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -26,7 +26,7 @@ Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` 
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
-If `true`, and `shareIdle == false`, idle allocations are created on a per cluster or per node basis rather than being aggregated into a single idle allocation. Default is `false`.
+If true, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is false.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}

--- a/apis/apis-overview/cloud-cost-api.md
+++ b/apis/apis-overview/cloud-cost-api.md
@@ -16,65 +16,15 @@ Samples full granularity of cloud costs from cloud billing report (ex. AWS' Cost
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" required="true" %}
-Window of the query.
-
-**Only accepts daily intervals**
-
-, example
-
-`window=3d`
-
-.
+Window of the query. **Only accepts daily intervals**, example `window=3d`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="CostMetric" required="false" %}
-Determines which cloud cost metric type will be returned. Acceptable values are
-
-`AmortizedNetCost`
-
-,
-
-`InvoicedCost`
-
-,
-
-`ListCost`
-
-, and
-
-`NetCost`
-
-. Default is
-
-`AmortizedNetCost`
-
-.
+Determines which cloud cost metric type will be returned. Acceptable values are `AmortizedNetCost`, `InvoicedCost`, `ListCost`, and `NetCost`. Default is `AmortizedNetCost`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" required="false" %}
-Field by which to aggregate the results. Accepts:
-
-`invoiceEntityID`
-
-,
-
-`accountID`
-
-,
-
-`provider`
-
-,
-
-`service`
-
-, and
-
-`label:<name>`
-
-. Supports multi-aggregation using comma-separated lists. Example:
-
-`aggregate=accountID,service`
+Field by which to aggregate the results. Accepts: `invoiceEntityID`, `accountID`, `provider`, `service`, and `label:<name>`. Supports multi-aggregation using comma-separated lists. Example: `aggregate=accountID,service`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterInvoiceEntityIDs" required="false" %}
@@ -139,37 +89,11 @@ Query cloud cost aggregate data
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" required="true" type="string" %}
-Window of the query. Accepts all standard Kubecost window formats (See our doc on using
-
-[the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)
-
-).
+Window of the query. Accepts all standard Kubecost window formats (See our doc on using [the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)).
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Field by which to aggregate the results. Accepts:
-
-`invoiceEntityID`
-
-,
-
-`accountID`
-
-,
-
-`provider`
-
-,
-
-`service`
-
-, and
-
-`label:<name>`
-
-. Supports multi-aggregation using comma-separated lists. Example:
-
-`aggregate=accountID,service`
+Field by which to aggregate the results. Accepts: `invoiceEntityID`, `accountID`, `provider`, `service`, and `label:<name>`. Supports multi-aggregation using comma-separated lists. Example: `aggregate=accountID,service`
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterInvoiceEntityIDs" type="string" required="false" %}

--- a/cost-events-audit-api.md
+++ b/cost-events-audit-api.md
@@ -16,35 +16,15 @@ Number of events to return. If unspecified, it returns all events available.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterNamespaces" type="string" required="false" %}
-Comma-separated list of namespaces to match; e.g.
-
-`namespace-one,namespace-two`
-
-will return change events that have occurred only in those two namespaces.
+Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` will return change events that have occurred only in those two namespaces.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterEventTypes" type="string" required="false" %}
-Filter query by event type. Currently, only
-
-`add`
-
-and
-
-`delete`
-
-are accepted. (more types coming soon) Also accepts comma-separated lists, like
-
-`add,delete`
-
-.
+Filter query by event type. Currently, only `add` and `delete` are accepted. (more types coming soon) Also accepts comma-separated lists, like `add,delete`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterResourceTypes" type="string" required="false" %}
-Resource type. Currently, only
-
-`deployment`
-
-is accepted. (more types coming soon)
+Resource type. Currently, only `deployment` is accepted. (more types coming soon)
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filterTotalCostLowerBound" type="float" required="false" %}


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

https://github.com/kubecost/docs/pull/722

## Proposed Changes

<!--
Describe the changes made in this PR.
-->

GitBook is currently investigating the cause of the issue. For now, this corrects all remaining API docs with incorrect formatting:
* Allocation API
* Allocation Trends API
* Cost Events API
* Cloud Cost API
