### PR TITLE
Updates Install Troubleshooting guide with additional example

### DIFF
--- a/troubleshoot-install.md
+++ b/troubleshoot-install.md
@@ -4,7 +4,7 @@ Once an installation is complete, access the Kubecost UI to view the status of t
 
 ## General troubleshooting commands
 
-These Kubernetes commands can be helpful when finding issues with deployments:
+These Kubernetes commands can be helpful when finding issues with deployments.
 
 This command will find all events that aren't normal, with the most recent listed last. Use this if pods are not even starting:
 
@@ -88,6 +88,10 @@ curl -X POST \
 A GET request can be sent to the same endpoint to retrieve the current log level.
 
 ## Other issues
+
+### Failed to download cost-analyzer Helm chart
+
+If your Kubecost installation fails and you are unable to download the cost-analyzer Helm chart from GitHub chart repository, run `helm repo update`, then run your install command again. The install should run successfully.
 
 ### Cost-model container Go panic on Azure Kubernetes Service (AKS) when using the Files Container Storage Interface (CSI) driver
 


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

<!--
Describe the changes made in this PR.
-->

Just wanted to add an example from my personal experience installing Kubecost, where re-installing Kubecost may result in a failure to grab the Helm chart. Not sure how universal this problem is or how commonly-known the solution should be, as it's very simple. Can someone maybe read this for accuracy? My specific error message is:

```
Error: INSTALLATION FAILED: failed to download "https://kubecost.github.io/cost-analyzer/cost-analyzer-1.106.2.tgz"
```

