### PR TITLE
Delete outages.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -147,7 +147,6 @@
 * [Security and Data Protection](security.md)
 * [Ports](ports.md)
 * [Kubecost Release Process](release-process.md)
-* [Outages](outages.md)
 
 ## Integrations
 

--- a/outages.md
+++ b/outages.md
@@ -1,3 +1,0 @@
-# Outages
-
-There are no known outages at this time. If you are experiencing an issue, please contact [support@kubecost.com](mailto:support@kubecost.com).


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

<!--
Describe the changes made in this PR.
-->

After internal talks, Outages is no longer needed. The Kubecost Cloud [Status Page](https://docs.kubecost.com/kubecost-cloud/receiving-kubecost-cloud-support#checking-kubecost-status) should be a sufficient replacement.


