### PR TITLE
Update install command for Kubecost Cloud

### DIFF
--- a/kubecost-cloud/cloud-installation-and-onboarding.md
+++ b/kubecost-cloud/cloud-installation-and-onboarding.md
@@ -48,13 +48,13 @@ Execute the following command to install the Kubecost Cloud agent to your cluste
 {% code overflow="wrap" %}
 ```
 helm upgrade --install kubecost-cloud \
---repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
+--repo https://kubecost.github.io/kubecost-cloud-agent/ kubecost-cloud-agent \
 --namespace kubecost-cloud --create-namespace \
--f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/develop/cost-analyzer/values-cloud-agent.yaml  \
---set imageVersion="lunar-sandwich.v0.0.11" \
+-f https://raw.githubusercontent.com/kubecost/kubecost-cloud-agent/main/values-cloud-agent.yaml \
+--set imageVersion="lunar-sandwich.v0.1.2" \
 --set cloudAgentKey="AGENTKEY" \
 --set cloudAgentClusterId="cluster-1" \
---set cloudReportingServer="collector.app.kubecost.com:31356" \
+--set cloudReportingServer="collector.app.kubecost.com:31357" \
 --set networkCosts.enabled=true
 ```
 {% endcode %}

--- a/kubecost-cloud/cloud-installation-and-onboarding.md
+++ b/kubecost-cloud/cloud-installation-and-onboarding.md
@@ -43,7 +43,7 @@ If no clusters are currently under management, you will find instructions on the
 
 Choose a unique ID for your cluster. This does not need to be the same name as your cluster, but it does need to be unique within your team.
 
-Execute the following command to install the Kubecost Cloud agent to your cluster:
+Execute the following command to install the Kubecost Cloud agent to your cluster. The agent key will be pre-populated in the install command in the Kubecost Cloud UI.
 
 {% code overflow="wrap" %}
 ```

--- a/kubecost-cloud/kubecost-cloud-architecture-overview.md
+++ b/kubecost-cloud/kubecost-cloud-architecture-overview.md
@@ -26,12 +26,13 @@ Remember to provide your correct agent key, cluster name, and reporting server i
 {% endhint %}
 
 ```sh
-helm upgrade kubecost cost-analyzer \
---repo https://kubecost.github.io/cost-analyzer/ \
---namespace kubecost-cloud \
+helm upgrade --install kubecost-cloud \
+--repo https://kubecost.github.io/kubecost-cloud-agent/ kubecost-cloud-agent \
+--namespace kubecost-cloud --create-namespace \
+-f https://raw.githubusercontent.com/kubecost/kubecost-cloud-agent/main/values-cloud-agent.yaml \
+--set imageVersion="lunar-sandwich.v0.1.2" \
 --set cloudAgentKey="AGENTKEY" \
---set cloudAgentClusterId="CLUSTER_NAME" \
---set cloudReportingServer="REPORTING_SERVER" \
---set networkCosts.enabled=false \
--f values-cloud-agent.yaml
+--set cloudAgentClusterId="cluster-1" \
+--set cloudReportingServer="collector.app.kubecost.com:31357" \
+--set networkCosts.enabled=false
 ```

--- a/kubecost-cloud/kubecost-cloud-architecture-overview.md
+++ b/kubecost-cloud/kubecost-cloud-architecture-overview.md
@@ -22,7 +22,7 @@ Kubecost Cloud uses an agent to gather metrics and send them to our SaaS platfor
 The network costs daemonSet will be installed to your Kubecost Cloud by default, however you can manually disable it by running this Helm upgrade command:
 
 {% hint style="info" %}
-Remember to provide your correct agent key, cluster name, and reporting server in the below example code block.
+Remember to provide your correct agent key and cluster ID in the below example code block.
 {% endhint %}
 
 ```sh

--- a/kubecost-cloud/kubecost-cloud-architecture-overview.md
+++ b/kubecost-cloud/kubecost-cloud-architecture-overview.md
@@ -19,7 +19,7 @@ Kubecost Cloud uses an agent to gather metrics and send them to our SaaS platfor
 
 ## Disabling the network costs daemonSet
 
-The network costs daemonSet will be installed to your Kubecost Cloud by default, however you can manually disable it by adjusting the Helm value, shown [here](https://github.com/kubecost/cost-analyzer-helm-chart/blob/fed60664f67ed5ef7b9e5947e7c28a9bde366cde/cost-analyzer/values.yaml#L682), or running this Helm upgrade command:
+The network costs daemonSet will be installed to your Kubecost Cloud by default, however you can manually disable it by running this Helm upgrade command:
 
 {% hint style="info" %}
 Remember to provide your correct agent key, cluster name, and reporting server in the below example code block.


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

N/A

## Proposed Changes

<!--
Describe the changes made in this PR.
-->

This PR updates the helm install command for KC Cloud to reference:
 - new repo
 - the latest agent image `lunar-sandwich.v0.1.2` 
 - server port `31357`


