### PR TITLE
Fix formatting on "Kubecost Metrics" page.

### DIFF
--- a/architecture/user-metrics.md
+++ b/architecture/user-metrics.md
@@ -29,7 +29,7 @@ The Cost Model both exports and consumes the following metrics.
 
 ## Kubecost Network Costs
 
-The Kubecost network-costs daemonset collects node network data and exports the egress, ingress, and performance statistics. 
+The Kubecost network-costs daemonset collects node network data and exports the egress, ingress, and performance statistics.
 
 | Metric                          | Description              |
 | ------------------------------- | ------------------------ |
@@ -56,12 +56,7 @@ GitHub: [https://github.com/google/cadvisor](https://github.com/google/cadvisor)
 | `container_cpu_cfs_periods_total` | Number of elapsed enforcement period intervals |
 | `container_cpu_cfs_throttled_periods_total` | Number of throttled period intervals |
 
-<<<<<<< HEAD:user-metrics.md
 ## Kube-State-Metrics (KSM)
-=======
-## Kube-State-Metrics
-The following KSM metrics are both consumed and emitted by the Kubecost installation. The `cost-model` replicates all of these metrics such that a KSM installation is not actually required. Read more in our [KSM Metrics](ksm-metrics.md) doc.
->>>>>>> main:architecture/user-metrics.md
 
 Although the default Kubecost installation does not include a [KSM deployment](https://github.com/kubernetes/kube-state-metrics), Kubecost does calculate & emit the below metrics. The below metrics and labels follow conventions of KSMv1, not KSMv2.
 


### PR DESCRIPTION
## Related issue #

None

## Proposed Changes

Previously, the doc had an unresolved merge conflict. This caused the doc to be rendered weird:

![Screenshot 2023-11-06 at 3 55 42 PM](https://github.com/kubecost/docs/assets/11251627/93a9fb51-9b33-4a95-a20e-b19fc8f1246c)
