### PR TITLE
Update microsoft-entra-id-oidc-integration-for-kubecost.md

### DIFF
--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -45,7 +45,9 @@ oidc:
   loginRedirectURL: "https://{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
   discoveryURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/v2.0/.well-known/openid-configuration"
 ```
-7. **Note**: When you use single Entra ID app to authenticate multiple kubecost endpoints, you must to pass additional redirect_uri parameter in your authURL as shown in below example; otherwise it is possible Entra ID app will Redirect you to to incorrect endpoint. read more at [Microsoft Entra ID is sending the token to an incorrect reply URL endpoint or localhost](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost)
+{% hint style="info" %}
+If you are using one Entra ID app to authenticate multiple Kubecost endpoints, you must to pass additional `redirect_uri` parameters in your `authURL` as shown in below example. Otherwise, Entra ID may redirect to an incorrect endpoint. You can read more about this in Microsoft Entra ID's [troubleshooting docs](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost).
+{% endhint %}
 
 ```
   authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"

--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -45,12 +45,13 @@ oidc:
   loginRedirectURL: "https://{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
   discoveryURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/v2.0/.well-known/openid-configuration"
 ```
+
 {% hint style="info" %}
 If you are using one Entra ID app to authenticate multiple Kubecost endpoints, you must to pass an additional `redirect_uri` parameter in your `authURL` as shown in below example, which will include the URI you configured in Step 1.4. Otherwise, Entra ID may redirect to an incorrect endpoint. You can read more about this in Microsoft Entra ID's [troubleshooting docs](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost).
 {% endhint %}
 
 ```
-  authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=https%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
+  authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=https://{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
 ```
 
 ### Step 3 (optional): Configuring RBAC

--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -50,7 +50,7 @@ If you are using one Entra ID app to authenticate multiple Kubecost endpoints, y
 {% endhint %}
 
 ```
-  authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
+  authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=https%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
 ```
 
 ### Step 3 (optional): Configuring RBAC

--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -45,6 +45,11 @@ oidc:
   loginRedirectURL: "https://{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
   discoveryURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/v2.0/.well-known/openid-configuration"
 ```
+7. **Note**: When you use single Entra ID app to authenticate multiple kubecost endpoints, you must to pass additional redirect_uri parameter in your authURL as shown in below example; otherwise it is possible Entra ID app will Redirect you to to incorrect endpoint. read more at [Microsoft Entra ID is sending the token to an incorrect reply URL endpoint or localhost](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost)
+
+```
+  authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
+```
 
 ### Step 3 (optional): Configuring RBAC
 

--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -46,7 +46,7 @@ oidc:
   discoveryURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/v2.0/.well-known/openid-configuration"
 ```
 {% hint style="info" %}
-If you are using one Entra ID app to authenticate multiple Kubecost endpoints, you must to pass additional `redirect_uri` parameters in your `authURL` as shown in below example. Otherwise, Entra ID may redirect to an incorrect endpoint. You can read more about this in Microsoft Entra ID's [troubleshooting docs](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost).
+If you are using one Entra ID app to authenticate multiple Kubecost endpoints, you must to pass an additional `redirect_uri` parameter in your `authURL` as shown in below example, which will include the URI you configured in Step 1.4. Otherwise, Entra ID may redirect to an incorrect endpoint. You can read more about this in Microsoft Entra ID's [troubleshooting docs](https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/reply-url-redirected-to-localhost).
 {% endhint %}
 
 ```


### PR DESCRIPTION
missing redirect_uri in authURL causes Azure/Entra ID to redirect to different endpoint when same Entra ID app is configured to authenticate multiple kubecost endpoints refer https://github.com/kubecost/docs/issues/814

## Related issue #
https://github.com/kubecost/docs/issues/814
<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes
When you use single Entra ID app to authenticate multiple kubecost endpoints, you must to pass additional redirect_uri parameter in your authURL as shown in below example; otherwise it is possible Entra ID app will Redirect you to to incorrect endpoint.
<!--
Describe the changes made in this PR.
-->



