### PR TITLE
Updates API docs to contain all Aggregator-related changes + general maintenance

### DIFF
--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -1,6 +1,6 @@
 # Allocation Trends API
 
-{% swagger method="get" path="/allocation/trends" baseUrl="http://<your-kubecost-address>/model" summary="Trends API" %}
+{% swagger method="get" path="/allocation/trends" baseUrl="http://<your-kubecost-address>/model" summary="Allocation Trends API" %}
 {% swagger-description %}
 Analyzes change in total cost of allocations relative to a previous window of the same size
 {% endswagger-description %}
@@ -11,6 +11,10 @@ Duration of time over which to query. Compares cost usage of window to cost usag
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
 Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
+When set to `false`, returns daily time series data vs. cumulative data. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="external" type="string" required="false" %}
@@ -95,9 +99,109 @@ Duration of a single allocation set. If unspecified, this defaults to the `windo
 {% endswagger-response %}
 {% endswagger %}
 
+{% swagger method="get" path="/allocation/trends" baseUrl="http://<your-kubecost-address>/model" summary="Allocation Trends API (Aggregator only)" %} {% swagger-description %} Analyzes change in allocated costs relative to a previous window of the same size. This Allocation Trends API should only be consulted for users who have configured [Kubecost Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md). {% endswagger-description %}
+
+{% swagger-parameter in="path" name="window" required="true" type="string" %}
+Duration of time over which to query. Compares cost usage of window to cost usage window of equal size directly preceding it. Accepts all standard Kubecost window formats (See our doc on using [the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)).
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="names" required="true" type="string" %}
+Determines order sequence of queried items via comma-separated list. Dependent on the value of `aggregate` to list items. See more [below](allocation-trends-api.md#using-the-names-parameter).
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
+{% endswagger-parameter %}
+
+% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
+When set to `false`, returns daily time series data vs. cumulative data. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="external" type="string" required="false" %}
+If `true`, include external costs in each allocation. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="idle" type="boolean" required="false" %}
+If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="filterNamespaces" type="string" required="false" %}
+Comma-separated list of namespaces to match; e.g. `namespace-one,namespace-two` will return results from only those two namespaces.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
+If true, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is false.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}
+Comma-separated list of namespaces to share; e.g. `kube-system, kubecost` will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareLabels" type="string" required="false" %}
+Comma-separated list of labels to share; e.g. `env:staging, app:test` will share the costs of those two label values with the remaining non-idle, unshared allocations.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareCost" type="float" required="false" %}
+Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. `30.42` ($1.00/day == $30.42/month) for the query `yesterday` (1 day) will split and distribute exactly $1.00 across the allocations. Default is `0.0.`
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareTenancyCosts" type="boolean" required="false" %}
+If `true`, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. Both cluster management and attached volumes are shared by cluster. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
+If `true`, idle allocations are created on a per node basis, which will result in different values when shared and more idle allocations when split. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="splitIdle" type="boolean" required="false" %}
+If `true`, and `shareIdle == false`, idle allocations are created on a per cluster or per node basis rather than being aggregated into a single idle allocation. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
+If `true`, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost categories cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="" %}
+<pre class="language-json"><code class="lang-json"><strong>{
+</strong>    
+{
+    "code": 200,
+    "data": {
+        "step": ,
+        "sets": [
+            {
+                "allocationTrends": {
+                    "aggregator": {
+                        "trends": {
+                            "costs": {
+                                "totalCost": {
+                                    "relativeChange": {
+                                        "isInfinite": false,
+                                        "isNaN": false,
+                                        "value": 
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                "window": {
+                    "start": "",
+                    "end": ""
+                }
+            }
+        ]
+      
+    }
+}
+</code></pre>
+{% endswagger-response %}
+{% endswagger %}
+
+
 ## Calculating trend value
 
-The Trends API determines changes in resource cost usage over time based on the interval set `window` parameter and provides that information via the schema field `value`. Cost usage for the current window sampled will be compared with the previous window, the window directly before the current window of the same size interval. For example, for `window=3d`, Kubecost will output cost usage for the past three days compared to cost usage of the three days before the start of the window. This means a total of six days of allocation are sampled in order to provide an accurate value.
+The Allocation Trends API determines changes in resource cost usage over time based on the interval set `window` parameter and provides that information via the schema field `value`. Cost usage for the current window sampled will be compared with the previous window, the window directly before the current window of the same size interval. For example, for `window=3d`, Kubecost will output cost usage for the past three days compared to cost usage of the three days before the start of the window. This means a total of six days of allocation data must be available and sampled in order to provide an accurate value.
 
 The equation for calculating `value` is: `value=current/previous - 1`
 
@@ -107,23 +211,30 @@ Receiving a positive `value` means your more recent `totalCost` has increased co
 It's important to recognize when a resource is not detected to exist in the previous window. This is designated by the field `IsInfinite=true`, which means the allocation could not be determined to exist. Otherwise, the cause of an unexpected or major trend change could be misattributed. The field `isNaN`, meaning not a number, refers to if the `value` is unreal. If so, `isNan` should return `true`, which means there was an error during calculation. Both fields should return `false` during a successful query.
 {% endhint %}
 
-In the example output below, `value` is expressed as `0.11...`, meaning spending has increased in the current window by roughly 11% from the previous window.
+In the example output below, `value` is expressed as `-0.27...`, meaning spending has decreased in the current window by roughly 27% from the previous window.
 
 ```json
-"etl-mount": {
-                "trends": {
-                    "costs": {
-                        "totalCost": {
-                            "relativeChange": {
-                                "isInfinite": false,
-                                "isNaN": false,
-                                "value": 0.11111005449714528
+                "allocationTrends": {
+                    "aggregator": {
+                        "trends": {
+                            "costs": {
+                                "totalCost": {
+                                    "relativeChange": {
+                                        "isInfinite": false,
+                                        "isNaN": false,
+                                        "value": -0.2786223889995989
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-            },
+                    },
 ```
+
+## Using the `names` parameter
+
+`names` is a mandatory parameter which determines the sequence of items returned, based on whatever the query is aggregating by. For example, when using `aggregate=namespace`, the user should provide a comma-separated list of all namespaces they wish to see trend values for in this category. In this case, they should provide `names=kubecost,aggregator,kube-system...` to receive a list of trend values for all provided namespaces as ordered. If the user does not provide a value for `aggregate`, they must still use the names parameter to list all line items requested.
+
+## Viewing trend percentages in the UI
 
 Trend values are converted into percentages in the Kubecost Allocations page, calculated based on your current query. Trends will be presented in the rightmost column, next to your Total cost. The `window` parameter is determined by your selected date range in the top right of the page. The default is Last 7 days (`window=7d`). The equation `value*100` is used to provide percentages.
 

--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -198,7 +198,6 @@ If `true`, pulls data from the Assets cache and corrects prices of Allocations a
 {% endswagger-response %}
 {% endswagger %}
 
-
 ## Calculating trend value
 
 The Allocation Trends API determines changes in resource cost usage over time based on the interval set `window` parameter and provides that information via the schema field `value`. Cost usage for the current window sampled will be compared with the previous window, the window directly before the current window of the same size interval. For example, for `window=3d`, Kubecost will output cost usage for the past three days compared to cost usage of the three days before the start of the window. This means a total of six days of allocation data must be available and sampled in order to provide an accurate value.

--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -163,9 +163,7 @@ If `true`, pulls data from the Assets cache and corrects prices of Allocations a
 
 {% swagger-response status="200: OK" description="" %}
 <pre class="language-json"><code class="lang-json"><strong>{
-</strong>    
-{
-    "code": 200,
+</strong>    "code": 200,
     "data": {
         "step": ,
         "sets": [

--- a/apis/apis-overview/allocation-trends-api.md
+++ b/apis/apis-overview/allocation-trends-api.md
@@ -113,7 +113,7 @@ Determines order sequence of queried items via comma-separated list. Dependent o
 Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
 {% endswagger-parameter %}
 
-% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
+{% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}
 When set to `false`, returns daily time series data vs. cumulative data. Default is `true`.
 {% endswagger-parameter %}
 

--- a/apis/apis-overview/api-allocation.md
+++ b/apis/apis-overview/api-allocation.md
@@ -209,7 +209,8 @@ Duration of each individual data metric across the `window`. Accepts `1h`, `1d`,
 
 {% swagger method="get" path="/allocation" baseUrl="http://<your-kubecost-address>/model" summary="Allocation API (Aggregator only)" %}
 {% swagger-description %}
-The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like `namespace`, `controller`, and `label`. Data is served from one of [Kubecost's ETL pipelines](/apis/deprecated-apis/cost-model-deprecated.md#caching-overview). This Allocation API should only be consulted for users who have configured [Kubecost Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md).
+The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like `namespace`, `controller`, and `label`. This Allocation API should only be consulted for users who have configured [Kubecost Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md).
+
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" type="string" required="true" %}

--- a/apis/apis-overview/api-allocation.md
+++ b/apis/apis-overview/api-allocation.md
@@ -241,7 +241,7 @@ Refers to the number of line items per page. Pair with the `offset` parameter to
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="filter" type="string" required="false" %}
-Filter your results by any category which you can aggregate by, can support multiple filterable items in the same category in a comma-separated list. For example, to filter results by clusters A and B, use `filter=cluster:clusterA,clusterB` See our [Filter Parameters](/apis/apis-overview/filters-api.md) doc for a complete explanation of how to use filters.
+Filter your results by any category which you can aggregate by, can support multiple filterable items in the same category in a comma-separated list. For example, to filter results by clusters A and B, use `filter=cluster:clusterA,clusterB` See our [Filter Parameters](/apis/apis-overview/filters-api.md) doc for a complete explanation of how to use filters and what categories are supported.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="format" type="string" required="false" %}

--- a/apis/apis-overview/api-allocation.md
+++ b/apis/apis-overview/api-allocation.md
@@ -69,6 +69,10 @@ Comma-separated list of services to match; e.g. `frontend-one,frontend-two` will
 Set to `csv` to download an accumulated version of the allocation results in CSV format. Set to `pdf` to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
 {% endswagger-parameter %}
 
+{% swagger-parameter in="path" name="format" type="string" required="false" %}
+Cost metric format. Learn about cost metric calculations in our [Allocations Dashboard](/using-kubecost/navigating-the-kubecost-ui/cost-allocation/README.md) doc. Supports `cumulative`, `hourly`, `daily`, and `monthly`. Default is `cumulative`.
+{% endswagger-parameter %}
+
 {% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
 If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is `false`.
 {% endswagger-parameter %}
@@ -79,6 +83,10 @@ If `true`, and `shareIdle == false`, Idle Allocations are created on a per clust
 
 {% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
 If `true`, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="includeSharedCostBreakdown" type="boolean" required="false" %}
+Provides breakdown of cost metrics for any shared resources. Default is `true`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
@@ -107,6 +115,181 @@ Determines how to split shared costs among non-idle, unshared allocations. By de
 
 {% swagger-parameter in="path" name="step" type="string" %}
 Duration of each individual data metric across the `window`. Accepts `1h`, `1d`, or `1w`. If left blank, defaults to longest step duration based on level of granularity of data represented by `window`.
+{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="" %}
+```json
+{
+    "code": 200,
+    "data": [
+        {
+            "aws-dev-1-niko/ip-192-168-12-152.us-east-2.compute.internal/kubecost/kubecost-cost-analyzer-5b84f94b7f-9lxx5/cost-model": {
+                "name": "aws-dev-1-niko/ip-192-168-12-152.us-east-2.compute.internal/kubecost/kubecost-cost-analyzer-5b84f94b7f-9lxx5/cost-model",
+                "properties": {
+                    "cluster": "aws-dev-1-niko",
+                    "node": "ip-192-168-12-152.us-east-2.compute.internal",
+                    "container": "cost-model",
+                    "controller": "kubecost-cost-analyzer",
+                    "controllerKind": "deployment",
+                    "namespace": "kubecost",
+                    "pod": "kubecost-cost-analyzer-5b84f94b7f-9lxx5",
+                    "services": [
+                        "kubecost-frontend",
+                        "kubecost-cost-analyzer"
+                    ],
+                    "providerID": "i-0f227c52893c7957f",
+                    "labels": {
+                        "app": "cost-analyzer",
+                        "app_kubernetes_io_instance": "kubecost",
+                        "app_kubernetes_io_name": "cost-analyzer",
+                        "kubernetes_io_metadata_name": "kubecost",
+                        "node_kubernetes_io_instance_type": "m5.large",
+                        "pod_template_hash": "5b84f94b7f"
+                    }
+                },
+                "window": {
+                    "start": "2023-01-27T23:00:00Z",
+                    "end": "2023-01-28T00:00:00Z"
+                },
+                "start": "2023-01-27T23:00:00Z",
+                "end": "2023-01-27T23:16:00Z",
+                "minutes": 16.000000,
+                "cpuCores": 0.050000,
+                "cpuCoreRequestAverage": 0.050000,
+                "cpuCoreUsageAverage": 0.000964,
+                "cpuCoreHours": 0.013333,
+                "cpuCost": 0.000426,
+                "cpuCostAdjustment": 0.000000,
+                "cpuEfficiency": 0.019287,
+                "gpuCount": 0.000000,
+                "gpuHours": 0.000000,
+                "gpuCost": 0.000000,
+                "gpuCostAdjustment": 0.000000,
+                "networkTransferBytes": 797941.832389,
+                "networkReceiveBytes": 1243829.277373,
+                "networkCost": 0.000000,
+                "networkCrossZoneCost": 0.000000,
+                "networkCrossRegionCost": 0.000000,
+                "networkInternetCost": 0.000000,
+                "networkCostAdjustment": 0.000000,
+                "loadBalancerCost": 0.003333,
+                "loadBalancerCostAdjustment": 0.000000,
+                "pvBytes": 16169288643.764706,
+                "pvByteHours": 4311810305.003922,
+                "pvCost": 0.000550,
+                "pvs": {
+                    "cluster=aws-dev-1-niko:name=pvc-16465f04-6464-483e-89af-9e68b4a59e72": {
+                        "byteHours": 4311810305.0039215,
+                        "cost": 0.0005500940102068225
+                    }
+                },
+                "pvCostAdjustment": 0.000000,
+                "ramBytes": 330301440.000000,
+                "ramByteRequestAverage": 330301440.000000,
+                "ramByteUsageAverage": 202833175.272727,
+                "ramByteHours": 88080384.000000,
+                "ramCost": 0.000351,
+                "ramCostAdjustment": 0.000000,
+                "ramEfficiency": 0.614085,
+                "sharedCost": 0.000000,
+                "externalCost": 0.000000,
+                "totalCost": 0.004661,
+                "totalEfficiency": 0.288087
+            },
+            "...etc": {}
+        },
+        {
+            "...etc": {}
+        }
+    ]
+}
+```
+{% endswagger-response %}
+{% endswagger %}
+
+{% swagger method="get" path="/allocation" baseUrl="http://<your-kubecost-address>/model" summary="Allocation API (Aggregator only)" %}
+{% swagger-description %}
+The Allocation API is the preferred way to query for costs and resources allocated to Kubernetes workloads and optionally aggregated by Kubernetes concepts like `namespace`, `controller`, and `label`. Data is served from one of [Kubecost's ETL pipelines](/apis/deprecated-apis/cost-model-deprecated.md#caching-overview). This Allocation API should only be consulted for users who have configured [Kubecost Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md).
+{% endswagger-description %}
+
+{% swagger-parameter in="path" name="window" type="string" required="true" %}
+Duration of time over which to query. Accepts words like `today`, `week`, `month`, `yesterday`, `lastweek`, `lastmonth`; durations like `30m`, `12h`, `7d`; comma-separated RFC3339 date pairs like `2021-01-02T15:04:05Z,2021-02-02T15:04:05Z`; comma-separated Unix timestamp (seconds) pairs like `1578002645,1580681045`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
+Field by which to aggregate the results. Accepts: `cluster`, `namespace`, `controllerKind`, `controller`, `service`, `node`, `pod`, `label:<name>`, and `annotation:<name>`. Also accepts comma-separated lists for multi-aggregation, like `namespace,label:app`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="accumulate" type="string" required="false" %}
+If `true`, sum the entire range of time intervals into a single set. Default value is `false`. Also supports accumulation by specific intervals of time including `hour`, `day`, and `week`. Does not accumulate idle costs, which must be configured separately.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="idle" type="boolean" required="false" %}
+If `true`, include idle cost (i.e. the cost of the un-allocated assets) as its own allocation. (See [special types of allocation](#special-types-of-allocation).) Default is `true.`
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="external" type="boolean" required="false" %}
+If `true`, include [external, or out-of-cluster costs](/install-and-configure/install/cloud-integration/README.md) in each allocation. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="offset" type="int" required="false" %}
+Refers to the number of pages you are searching through which will increase by integers for the amount of pages you want to skip. Starting value is `0`, representing the first page of results.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="limit" type="int" required="false" %}
+Refers to the number of line items per page. Pair with the `offset` parameter to filter your payload to specific sections of line items. You should also set `accumulate=true` to obtain a single list of line items, otherwise you will receive a group of line items per interval of time being sampled.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="filter" type="string" required="false" %}
+Filter your results by any category which you can aggregate by, can support multiple filterable items in the same category in a comma-separated list. For example, to filter results by clusters A and B, use `filter=cluster:clusterA,clusterB` See our [Filter Parameters](/apis/apis-overview/filters-api.md) doc for a complete explanation of how to use filters.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="format" type="string" required="false" %}
+Set to `csv` to download an accumulated version of the allocation results in CSV format. Set to `pdf` to download an accumulated version of the allocation results in PDF format. By default, results will be in JSON format.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="format" type="string" required="false" %}
+Cost metric format. Learn about cost metric calculations in our [Allocations Dashboard](/using-kubecost/navigating-the-kubecost-ui/cost-allocation/README.md) doc. Supports `cumulative`, `hourly`, `daily`, and `monthly`. Default is `cumulative`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareIdle" type="boolean" required="false" %}
+If `true`, idle cost is allocated proportionally across all non-idle allocations, per-resource. That is, idle CPU cost is shared with each non-idle allocation's CPU cost, according to the percentage of the total CPU cost represented. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="splitIdle" type="boolean" required="false" %}
+If `true`, and `shareIdle == false`, Idle Allocations are created on a per cluster or per node basis rather than being aggregated into a single "_idle_" allocation. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="idleByNode" type="boolean" required="false" %}
+If `true`, idle allocations are created on a per node basis. Which will result in different values when shared and more idle allocations when split. Default is `false`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="includeSharedCostBreakdown" type="boolean" required="false" %}
+Provides breakdown of cost metrics for any shared resources. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="reconcile" type="boolean" required="false" %}
+If `true`, pulls data from the Assets cache and corrects prices of Allocations according to their related Assets. The corrections from this process are stored in each cost category's cost adjustment field. If the integration with your cloud provider's billing data has been set up, this will result in the most accurate costs for Allocations. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareTenancyCosts" type="boolean" required="false" %}
+If `true`, share the cost of cluster overhead assets such as cluster management costs and node attached volumes across tenants of those resources. Results are added to the sharedCost field. As of v1.93.0 both cluster management and attached volumes are shared by cluster. Default is `true`.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareNamespaces" type="string" required="false" %}
+Comma-separated list of namespaces to share; e.g. `kube-system, kubecost` will share the costs of those two namespaces with the remaining non-idle, unshared allocations.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareLabels" type="string" required="false" %}
+Comma-separated list of labels to share; e.g. `env:staging, app:test` will share the costs of those two label values with the remaining non-idle, unshared allocations.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareCost" type="float" required="false" %}
+Floating-point value representing a monthly cost to share with the remaining non-idle, unshared allocations; e.g. `30.42` ($1.00/day == $30.42/month) for the query `yesterday` (1 day) will split and distribute exactly $1.00 across the allocations. Default is `0.0.`
+{% endswagger-parameter %}
+
+{% swagger-parameter in="path" name="shareSplit" type="string" required="false" %}
+Determines how to split shared costs among non-idle, unshared allocations. By default, the split will be `weighted`; i.e. proportional to the cost of the allocation, relative to the total. The other option is `even`; i.e. each allocation gets an equal portion of the shared cost. Default is `weighted`.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}
@@ -453,6 +636,70 @@ $ curl http://localhost:9090/model/allocation \
 ```
 {% endtab %}
 {% endtabs %}
+
+## Querying with `/summary` endpoint to view condensed payload per line item
+
+`/summary` is an optional API endpoint which can be added to your Allocation query via `.../model/allocation/summary?window=...` to provide a condensed list of your cost metrics per line item. Instead of returning the full list of schema values listed above, your query will return something like:
+
+```
+"allocation-line-item": {
+                        "name": "allocation-line-tem",
+                        "start": "",
+                        "end": "",
+                        "cpuCoreRequestAverage": ,
+                        "cpuCoreUsageAverage": ,
+                        "cpuCost": ,
+                        "gpuCost": ,
+                        "networkCost": ,
+                        "loadBalancerCost": ,
+                        "pvCost": ,
+                        "ramByteRequestAverage": ,
+                        "ramByteUsageAverage": ,
+                        "ramCost": ,
+                        "sharedCost": ,
+                        "externalCost": ,
+                        "totalEfficiency": ,
+                        "totalCost":
+                    },
+```
+
+## Querying with `/topline` endpoint to view cost totals across query (Aggregator only)
+
+`/topline` is an optional API endpoint which can be added to your `/summary` Allocation query via `.../model/allocation/summary/topline?window=...` to provide a condensed overview of your total cost metrics including all line items sampled. You will receive a single list which sums the values per all items queried, formatted similar to a regular `/summary` query, where `numResults` displays the total number of items sampled. Idle costs still need to be configured separately.
+
+```
+{
+    "code": 200,
+    "data": {
+        "numResults": ,
+        "combined": {
+            "allocations": {
+                "total": {
+                    "name": "total",
+                    "start": "",
+                    "end": "",
+                    "cpuCoreRequestAverage": ,
+                    "cpuCoreUsageAverage": ,
+                    "cpuCost": ,
+                    "gpuCost": ,
+                    "networkCost": ,
+                    "loadBalancerCost": ,
+                    "pvCost": ,
+                    "ramByteRequestAverage": ,
+                    "ramByteUsageAverage": ,
+                    "ramCost": ,
+                    "sharedCost": ,
+                    "externalCost": 
+                }
+            },
+            "window": {
+                "start": "",
+                "end": ""
+            }
+        }
+    }
+}
+```
 
 ## Allocation of asset costs
 

--- a/apis/apis-overview/api-request-right-sizing-v2.md
+++ b/apis/apis-overview/api-request-right-sizing-v2.md
@@ -109,13 +109,13 @@ curl -G \
 
 ## Querying with `/topline` endpoint to view cost totals across query (Aggregator only)
 
-`/topline` is an optional API endpoint which can be added to your right-sizing query via `.../savings/RequestSizingV2/topline...` to provide a condensed overview of all items sampled. `TotalMonthlySavings` is the total estimated savings value from adopting right-sizing recommendations. `Count` refers to the number of items sampled. `Recommendation` should return `null`, as it is unable to provide a universal right-sizing recommendation.
+`/topline` is an optional API endpoint which can be added to your right-sizing query via `.../savings/RequestSizingV2/topline...` to provide a condensed overview of all items sampled. `TotalMonthlySavings` is the total estimated savings value from adopting right-sizing recommendations. `Count` refers to the number of items sampled. `Recommendations` should return `null`, as it is unable to provide a universal right-sizing recommendation.
 
 ```
 {
     "TotalMonthlySavings": ,
     "Count": ,
-    "Recommendations": 
+    "Recommendations": null 
 }
 ```
 

--- a/apis/apis-overview/api-request-right-sizing-v2.md
+++ b/apis/apis-overview/api-request-right-sizing-v2.md
@@ -44,7 +44,7 @@ Required parameter. Duration of time over which to calculate usage. Supports day
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="filter" type="string" required="false" %}
-A filter to reduce the set of workloads for which recommendations will be calculated. See [Filter parameters](filters-api.md) for syntax. V1 filters are also supported.
+A filter to reduce the set of workloads for which recommendations will be calculated. See our [Filter Parameters](filters-api.md) doc for syntax. v1 filters are also supported.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="sortBy" type="string" required="false" %}
@@ -105,6 +105,18 @@ curl -G \
   -d 'window=3d' \
   --data-urlencode 'filter=namespace:"kubecost"+container:"cost-model"' \
   ${KUBECOST_ADDRESS}/savings/requestSizingV2
+```
+
+## Querying with `/topline` endpoint to view cost totals across query (Aggregator only)
+
+`/topline` is an optional API endpoint which can be added to your right-sizing query via `.../savings/RequestSizingV2/topline...` to provide a condensed overview of all items sampled. `TotalMonthlySavings` is the total estimated savings value from adopting right-sizing recommendations. `Count` refers to the number of items sampled. `Recommendation` should return `null`, as it is unable to provide a universal right-sizing recommendation.
+
+```
+{
+    "TotalMonthlySavings": ,
+    "Count": ,
+    "Recommendations": 
+}
 ```
 
 ## Recommendation methodology

--- a/apis/apis-overview/apis-overview.md
+++ b/apis/apis-overview/apis-overview.md
@@ -14,7 +14,7 @@ The Allocation API retrieves cost allocation information for any Kubernetes conc
 
 ### [Allocation Trends API](allocation-trends-api.md)
 
-The Trends API compares cost usage between two windows of the same duration and presents a percentage value showing the change in cost.
+The Allocation Trends API compares cost usage between two windows of the same duration and presents a percentage value showing the change in cost.
 
 ### [**Assets API**](assets-api.md)
 
@@ -27,6 +27,10 @@ The Asset Diff API compares two asset sets between two windows of the same durat
 ### [Cloud Costs API](cloud-cost-api.md)
 
 The Cloud Costs API retrieves cloud cost data from cloud providers by reading cost and usage reports.
+
+### [Cloud Cost Trends API](cloud-cost-api/cloud-cost-trends-api.md)
+
+The Cloud Cost Trends API compares cost usage between two windows of the same duration and presents a percentage value showing the change in cloud costs.
 
 ## Governance APIs
 

--- a/apis/apis-overview/apis-overview.md
+++ b/apis/apis-overview/apis-overview.md
@@ -2,6 +2,10 @@
 
 Welcome to the Kubecost API library! This directory will show you how Kubecost APIs can assist in monitoring, maintaining, and optimizing your cloud spend. Learn also how Kubecost APIs power different features of the UI below.
 
+{% hint style="info" %}
+Throughout our API documentation, you may see two separate endpoints for the same API, with one labeled 'Aggrgegator-only', or a subsection in an article for Aggregator-only parameters. Those endpoints or parameters are only for users who have configured [Kubecost Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md). If you do not have Aggregator configured in your environment, do not use those Aggregator endpoints or parameters.
+{% endhint %}
+
 ## Monitoring APIs
 
 ### [**Allocation API**](api-allocation.md)
@@ -59,7 +63,7 @@ Many, but not all, Kubecost APIs power different features in the Kubecost UI. Th
 | API Name                                          | UI Equivalent                                                                                                                                    |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Allocation API                                    | [Allocations dashboard](/using-kubecost/navigating-the-kubecost-ui/cost-allocation/README.md)                                                |
-| Allocation Trends API                             | Allocations dashboard, Total cost column percentage                                                                                              |
+| Allocation/Cloud Cost Explorer Trends API         | Allocations/Cloud Cost Explorer dashboards, Total cost column percentage                                                                                              |
 | Assets API                                        | [Assets dashboard](/using-kubecost/navigating-the-kubecost-ui/assets.md)                                                              |
 | Cloud Cost API                                    | [Cloud Costs Explorer dashboard](/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer.md)                                  |
 | Budget API                                        | [Budgets dashboard](/using-kubecost/navigating-the-kubecost-ui/budgets.md)                                                            |

--- a/apis/apis-overview/assets-api.md
+++ b/apis/apis-overview/assets-api.md
@@ -71,7 +71,8 @@ Dictates the applicable window for measuring historical asset cost.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Used to consolidate cost model data. Supported values are `account`, `cluster`, `project`, `providerid`, `provider`, and `type`. Passing an empty value for this parameter or none at all returns data by an individual asset. Supports multi-aggregation (aggregation fo multiple categories) in a comma separated list, such as `aggregate=account,project`.
+Used to consolidate cost model data. Supported values are `account`, `cluster`, `project`, `providerid`, `provider`, and `type`. Passing an empty value for this parameter or none at all returns data by an individual asset. Supports multi-aggregation (aggregation of multiple categories) in a comma separated list, such as `aggregate=account,project`.
+
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}

--- a/apis/apis-overview/assets-api.md
+++ b/apis/apis-overview/assets-api.md
@@ -10,7 +10,8 @@ Dictates the applicable window for measuring historical asset cost.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}
-Used to consolidate cost model data. Supported values are `account`, `cluster`, `project`, `providerid`, `provider`, and `type`. Passing an empty value for this parameter or none at all returns data by an individual asset. Supports multi-aggregation (aggregation fo multiple categories) in a comma separated list, such as `aggregate=account,project`.
+Used to consolidate cost model data. Supported values are `account`, `cluster`, `project`, `providerid`, `provider`, and `type`. Passing an empty value for this parameter or none at all returns data by an individual asset. Supports multi-aggregation (aggregation of multiple categories) in a comma separated list, such as `aggregate=account,project`.
+
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="accumulate" type="boolean" required="false" %}

--- a/apis/apis-overview/cloud-cost-api/cloud-cost-trends-api.md
+++ b/apis/apis-overview/cloud-cost-api/cloud-cost-trends-api.md
@@ -3,14 +3,14 @@
 {% hint style="warning" %} This feature is only available in [Kubecost Aggregator](../../../install-and-configure/install/multi-cluster/federated-etl/aggregator.md).
 {% endhint %}
 
-{% swagger method="get" path="/cloudCost/view/trends" baseUrl="http://<your-kubecost-address>/model" summary="Trends API" %} {% swagger-description %} Analyzes change in cloud costs relative to a previous window of the same size {% endswagger-description %}
+{% swagger method="get" path="/cloudCost/view/trends" baseUrl="http://<your-kubecost-address>/model" summary="Cloud Cost Trends API" %} {% swagger-description %} Analyzes change in cloud costs relative to a previous window of the same size {% endswagger-description %}
 
 {% swagger-parameter in="path" name="window" required="true" type="string" %}
 Duration of time over which to query. Compares cost usage of window to cost usage window of equal size directly preceding it. Accepts all standard Kubecost window formats (See our doc on using [the `window` parameter](https://docs.kubecost.com/apis/apis-overview/assets-api#using-window-parameter)).
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="names" required="true" type="string" %}
-Determines order sequence of queried items via comma-separated list. Dependent on the value of `aggregateBy` to list items. See more [below](cloud-cost-trends-api.md#using-the-names-parameter).
+Determines order sequence of queried items via comma-separated list. Dependent on the value of `aggregate` to list items. See more [below](cloud-cost-trends-api.md#using-the-names-parameter).
 {% endswagger-parameter %}
 
 {% swagger-parameter in="path" name="aggregate" type="string" required="false" %}


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

API docs will now provide Aggregator-only parameters and endpoints if applicable, docs have also added clarity to parameter/usage information

Aggregator endpoints/params are added alongside standard self-hosted Kubecost, so users will be supported on both versions. Aggregator-only features are always labeled as such.
