### PR TITLE
added Legacy CUR reference

### DIFF
--- a/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integrations.md
+++ b/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integrations.md
@@ -22,9 +22,10 @@ Integrating your AWS account with Kubecost may be a complicated process if you a
 
 ### Step 1: Setting up a CUR
 
-Follow [these steps](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html) to set up a CUR using the settings below.
+Follow [these steps](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html) to set up a Legacy CUR using the settings below.
 
-* For time granularity, select _Daily_.
+* Select the _Legacy CUR export_ type.
+*  For time granularity, select _Daily_.
 * Select the checkbox to enable _Resource IDs_ in the report.
 * Select the checkbox to enable _Athena integration_ with the report.
 

--- a/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integrations.md
+++ b/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integrations.md
@@ -25,7 +25,7 @@ Integrating your AWS account with Kubecost may be a complicated process if you a
 Follow [these steps](https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html) to set up a Legacy CUR using the settings below.
 
 * Select the _Legacy CUR export_ type.
-*  For time granularity, select _Daily_.
+* For time granularity, select _Daily_.
 * Select the checkbox to enable _Resource IDs_ in the report.
 * Select the checkbox to enable _Athena integration_ with the report.
 


### PR DESCRIPTION
## Related issue #

AWS has added CUR 2.0: https://aws.amazon.com/blogs/aws-cloud-financial-management/introducing-data-exports-for-billing-and-cost-management/

With this there is a new option / Kubecost requirement on the CUR Export creation page to select the "Legacy CUR export" button prior to being able to select all of the other required settings.

Note the AWS documentation is now titled: **Legacy Cost and Usage Reports**
https://docs.aws.amazon.com/cur/latest/userguide/cur-create.html




<img width="1453" alt="Screenshot 2023-12-26 at 4 08 50 PM" src="https://github.com/kubecost/docs/assets/17748044/8741e2d7-9834-493a-af45-e9e3d339a4bb">


