### PR TITLE
fix aws spot invalid IAM

### DIFF
--- a/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-spot-instances.md
+++ b/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-spot-instances.md
@@ -45,8 +45,6 @@ Kubecost requires read access to the Spot data feed bucket. The following IAM po
         "Action": [
           "s3:ListAllMyBuckets",
           "s3:ListBucket",
-          "s3:HeadBucket",
-          "s3:HeadObject",
           "s3:List*",
           "s3:Get*"
         ],


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

<!--
Describe the changes made in this PR.
-->

AWS Policy Editor says s3:HeadBucket and s3:HeadObject" are invalid. These operations appear to use List Permissions instead. 

https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html



