### PR TITLE
Clean up "Cloud Costs" to match the feature name

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -132,7 +132,7 @@
   * [Cloud Cost API](apis/apis-overview/cloud-cost-api.md)
     * [Cloud Cost Metrics](apis/apis-overview/cloud-cost-api/cloud-cost-metrics.md)
     * [Cloud Cost Trends API](apis/apis-overview/cloud-cost-api/cloud-cost-trends-api.md)
-  * [CloudCost Diagnostic APIs](apis/apis-overview/cloudcost-diagnostic-apis.md)
+  * [Cloud Cost Diagnostic APIs](apis/apis-overview/cloudcost-diagnostic-apis.md)
   * [Budget API](apis/apis-overview/budget-api.md)
   * [Cost Events Audit API](apis/apis-overview/cost-events-audit-api.md)
   * [Spec Cost Prediction API](apis/apis-overview/spec-cost-prediction-api.md)

--- a/apis/apis-overview/cloudcost-diagnostic-apis.md
+++ b/apis/apis-overview/cloudcost-diagnostic-apis.md
@@ -1,4 +1,4 @@
-# CloudCost Diagnostic APIs
+# Cloud Cost Diagnostic APIs
 
 These APIs are designed to help troubleshoot and provide diagnostics for Kubecost's cloud integration features like Cloud Usage and reconciliation. For an explanation of these integration features, review Kubecost's [cloud processes](/install-and-configure/install/cloud-integration/README.md#kubecosts-cloud-processes).
 

--- a/install-and-configure/advanced-configuration/resource-consumption.md
+++ b/install-and-configure/advanced-configuration/resource-consumption.md
@@ -4,9 +4,9 @@ Kubecost can run on clusters with thousands of nodes when resource consumption i
 
 ![Memory Reduction Steps](/images/resource-consumption.png)
 
-## Disable CloudCost on secondary clusters
+## Disable Cloud Costs on secondary clusters
 
-[CloudCost](/install-and-configure/install/cloud-integration/README.md#cloudcost) allows Kubecost to pull in spend data from your integrated cloud service providers.
+[Cloud Costs](/install-and-configure/install/cloud-integration/README.md#cloudcost) allow Kubecost to pull in spend data from your integrated cloud service providers.
 
 Cloud cost metrics for all accounts can be pulled in on your primary cluster by pointing Kubecost to one or more management accounts. Therefore, you can disable CloudCost on secondary clusters by setting the following Helm value:
 

--- a/install-and-configure/install/cloud-integration/README.md
+++ b/install-and-configure/install/cloud-integration/README.md
@@ -8,7 +8,7 @@ If you are using Kubecost Cloud, do not attempt to modify your install using inf
 
 ## Kubecost's cloud processes
 
-As indicated above, setting up a cloud integration with your CSP allows Kubecost to pull in additional billing data. The two processes that incorporate this information are **reconciliation** and **CloudCost** (formerly known as CloudUsage).
+As indicated above, setting up a cloud integration with your CSP allows Kubecost to pull in additional billing data. The two processes that incorporate this information are **reconciliation** and **Cloud Costs** (formerly known as CloudUsage).
 
 ### Reconciliation
 
@@ -30,17 +30,17 @@ Visit _Settings_, then toggle on _Highlight Unreconciled Costs_, then select _Sa
 
 ![Allocations dashboard with highlighted unreconciled costs](/images/unreconciled.png)
 
-### CloudCost
+### Cloud Costs
 
 {% hint style="info" %}
-As of v1.106 of Kubecost, CloudCost is enabled by default, and Cloud Usage is disabled. Upgrading Kubecost will not affect the UI or hinder performance relating to this.
+As of v1.106 of Kubecost, Cloud Costs are enabled by default, and Cloud Usage is disabled. Upgrading Kubecost will not affect the UI or hinder performance relating to this.
 {% endhint %}
 
-CloudCost allows Kubecost to pull in OOC cloud spend from your CSP's billing data, including any services run by the CSP as well as compute resources. By labelling OOC costs, their value can be distributed to your Allocations data as external costs. This allows you to better understand the proportion of OOC cloud spend that your in-cluster usage depends on.
+Cloud Costs allow Kubecost to pull in OOC cloud spend from your CSP's billing data, including any services run by the CSP as well as compute resources. By labelling OOC costs, their value can be distributed to your Allocations data as external costs. This allows you to better understand the proportion of OOC cloud spend that your in-cluster usage depends on.
 
 Your cloud billing data is reflected in the aggregate costs of `Account`, `Provider`, `Invoice Entity`, and `Service`. Aggregating and drilling down into any of these categories will provide a subset of the entire bill, based on the Helm value `.values.cloudCost.topNItems`, which will log 1,000 values. This subset is each days' top `n` items by cost. An optional [label list](https://github.com/kubecost/cost-analyzer-helm-chart/blob/19b26585dca160446c1535518da557dd5f43f6e3/cost-analyzer/values.yaml#L458-L461) can be used to include or exclude items to be pulled from the bill.
 
-CloudCost becomes available as soon as they appear in the billing data, with the 6 to 24-hour delay mentioned above, and are updated as they become more complete.
+Cloud Costs become available as soon as they appear in the billing data, with the 6 to 24-hour delay mentioned above, and are updated as they become more complete.
 
 ## Managing cloud integrations
 
@@ -112,4 +112,4 @@ After starting or restarting Cloud Usage or reconciliation, two subprocesses are
 * Resolution: The window size of the process
 * StartTime: When the Cloud Process was started
 
-For more information on APIs related to rebuilding and repairing Cloud Usage or reconciliation, see the [CloudCost Diagnostic APIs](/apis/apis-overview/cloudcost-diagnostic-apis.md) doc.
+For more information on APIs related to rebuilding and repairing Cloud Usage or reconciliation, see the [Cloud Cost Diagnostic APIs](/apis/apis-overview/cloudcost-diagnostic-apis.md) doc.

--- a/install-and-configure/install/cloud-integration/gcp-out-of-cluster/README.md
+++ b/install-and-configure/install/cloud-integration/gcp-out-of-cluster/README.md
@@ -14,7 +14,7 @@ A GitHub repository with sample files used in the below instructions can be foun
 
 Begin by reviewing [Google's documentation](https://cloud.google.com/billing/docs/how-to/export-data-bigquery) on exporting cloud billing data to BigQuery.
 
-GCP users must create a [detailed billing export](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables#detailed-usage-cost-data-schema) to gain access to all Kubecost CloudCost features including [reconciliation](/install-and-configure/install/cloud-integration/README.md#reconciliation). Exports of type "Standard usage cost data" and "Pricing Data" do not have the correct information to support CloudCosts.
+GCP users must create a [detailed billing export](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-tables#detailed-usage-cost-data-schema) to gain access to all Kubecost Cloud Costs features including [reconciliation](/install-and-configure/install/cloud-integration/README.md#reconciliation). Exports of type "Standard usage cost data" and "Pricing Data" do not have the correct information to support Cloud Costs.
 
 ## Step 2: Create a GCP service account
 


### PR DESCRIPTION
Replace “CloudCosts” and “Cloud Cost” with “Cloud Costs”, since that's what's in the UI. Didn't change ETL and API references, except when referring to the feature.

