### PR TITLE
Clarifies how users must configure currency types in Kubecost

### DIFF
--- a/apis/apis-overview/budget-api.md
+++ b/apis/apis-overview/budget-api.md
@@ -173,7 +173,7 @@ When providing values for `actions`, `percentage` refers to the percentage of `s
 
 Kubecost supports configuration of the following currency types: USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, and SEK. Kubecost does *not* perform any currency conversion when switching currency types; it is for display purposes, therefore you should ideally match your currency type to the type in your original cloud bill(s).
 
-Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
+Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `.Values.kubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
 
 ```
 --set kubecostProductConfigs.currencyCode=EUR

--- a/apis/apis-overview/budget-api.md
+++ b/apis/apis-overview/budget-api.md
@@ -171,9 +171,13 @@ When providing values for `actions`, `percentage` refers to the percentage of `s
 
 ## Configuring currency
 
-The `spendLimit` parameter will always be determined using your configured currency type. You can manually change your currency type in Kubecost by selecting _Settings_, then scrolling to Currency and selecting your desired currency from the dropdown (remember to confirm your choice by selecting _Save_ at the bottom of the page).
+Kubecost supports configuration of the following currency types: USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, and SEK. Kubecost does *not* perform any currency conversion when switching currency types; it is for display purposes, therefore you should ideally match your currency type to the type in your original cloud bill(s).
 
-Kubecost does **not** convert spending costs to other currency types; it will only change the symbol displayed in the UI next to costs. For best results, configure your currency to what matches your spend.
+Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
+
+```
+--set KubecostProductConfigs.currencyCode=EUR
+```
 
 ## Examples
 

--- a/apis/apis-overview/budget-api.md
+++ b/apis/apis-overview/budget-api.md
@@ -176,7 +176,7 @@ Kubecost supports configuration of the following currency types: USD, AUD, BRL, 
 Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
 
 ```
---set KubecostProductConfigs.currencyCode=EUR
+--set kubecostProductConfigs.currencyCode=EUR
 ```
 
 ## Examples

--- a/install-and-configure/install/first-time-user-guide.md
+++ b/install-and-configure/install/first-time-user-guide.md
@@ -18,6 +18,14 @@ Due to the frequency of updates from providers, it can take anywhere from 24 to 
 
 Now that your base install and CSP integrations are complete, it's time to determine the accuracy against your cloud bill. Based on different methods of cost aggregation, Kubecost should assess your billing data within a 3-5% margin of error.
 
+You can also configure your currency display type. Kubecost supports the following currency types: USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, and SEK. Kubecost does *not* perform any currency conversion when switching currency types; it is for display purposes, therefore you should ideally match your currency type to the type in your original cloud bill(s).
+
+Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
+
+```
+--set KubecostProductConfigs.currencyCode=EUR
+```
+
 ### Monitoring your cost billing
 
 After enabling port-forwarding, you should have access to the Kubecost UI. Explore the different pages in the left navigation, starting with the Monitor dashboards. These pages, including Allocations, Assets, Clusters, and Cloud Costs, are comprised of different categories of cost spending, and allow you to apply customized queries for specific billing data. These queries can then be saved in the form of reports for future quick access. Each page of the Kubecost UI has more dedicated information in the [Navigating the Kubecost UI](/using-kubecost/navigating-the-kubecost-ui/README.md) group.

--- a/install-and-configure/install/first-time-user-guide.md
+++ b/install-and-configure/install/first-time-user-guide.md
@@ -20,7 +20,7 @@ Now that your base install and CSP integrations are complete, it's time to deter
 
 You can also configure your currency display type. Kubecost supports the following currency types: USD, AUD, BRL, CAD, CHF, CNY, DKK, EUR, GBP, IDR, INR, JPY, NOK, PLN, and SEK. Kubecost does *not* perform any currency conversion when switching currency types; it is for display purposes, therefore you should ideally match your currency type to the type in your original cloud bill(s).
 
-Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
+Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `.Values.kubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
 
 ```
 --set kubecostProductConfigs.currencyCode=EUR

--- a/install-and-configure/install/first-time-user-guide.md
+++ b/install-and-configure/install/first-time-user-guide.md
@@ -23,7 +23,7 @@ You can also configure your currency display type. Kubecost supports the followi
 Currency type can only be changed via a [`helm` upgrade to your *values.yaml*](/install-and-configure/install/helm-install-params.md), using the flag `KubecostProductConfigs.currencyCode`. For example, if you needed to convert your currency type to EUR, you would add the following to your `helm` command:
 
 ```
---set KubecostProductConfigs.currencyCode=EUR
+--set kubecostProductConfigs.currencyCode=EUR
 ```
 
 ### Monitoring your cost billing

--- a/troubleshooting/frequently-asked-questions.md
+++ b/troubleshooting/frequently-asked-questions.md
@@ -148,5 +148,6 @@ A. To receive access to these features, you need to properly configure Workload 
 Q: How can I configure node-exporter to use an internal cluster IP instead of the node network?\
 A: Set the following Helm value: `prometheus.nodeExporter.hostNetwork=false`.
 
-Q: How cna I configure my displayed currency type?/
+Q: How can I configure my displayed currency type?/
+
 A: Kubecost supports multiple different currency types for display purposes, but does not perform direct currency conversion. This must be configured via your *values.yaml* with the flag `kubecostProductConfigs.currencyCode`.

--- a/troubleshooting/frequently-asked-questions.md
+++ b/troubleshooting/frequently-asked-questions.md
@@ -3,9 +3,6 @@
 Q: How can I reduce CPU or Memory resource consumption by Kubecost?\
 A: Please review our [Tuning Resource Consumption guide](/install-and-configure/advanced-configuration/resource-consumption.md).
 
-Q: Can I safely configure Thanos Compaction [down sampling](https://thanos.io/tip/components/compact.md/#downsampling)?\
-A: Yes, Kubecost is resilient to downsampling. However turning query concurrency is going to be most beneficial, especially during the long rebuild windows. To tune downsampling use the following Thanos subchart [values](https://github.com/kubecost/cost-analyzer-helm-chart/blob/b5b089ce217636fb2b7e6f42daed37397d28d3aa/cost-analyzer/charts/thanos/values.yaml#L525-L530).
-
 Q: Why do I receive a 403 error when trying to save reports or alerts?\
 A: This is due to the SAML user having read-only RBAC permissions.
 
@@ -46,7 +43,7 @@ Q: What license does the Enterprise version of Kubecost use?\
 A: Paid Kubecost versions use our [EULA](https://www.kubecost.com/terms).
 
 Q: When configuring Spot feeds in a federated cluster, where should it be configured?\
-A: The Spot data feed is meant to supplement node prices before the CUR drops. Because of this, it should be configured in each cluster to give the most accurate estimates as the data needs to be written into Thanos.
+A: The Spot data feed is meant to supplement node prices before the CUR drops. Because of this, it should be configured in each cluster to give the most accurate estimates.
 
 Q: Does the Abandoned Workloads savings report rely on the Network Traffic daemonSet?\
 A: No, it uses cAdvisor metrics.
@@ -56,9 +53,6 @@ A: No, the reason is that we get GPU efficiency from integration with the Nvidia
 
 Q: Should I use amortized prices when setting up my CUR or billing export?\
 A: Yes, amortized allows upfront costs of the resources to appear in Kubecost. [More info here](/install-and-configure/install/cloud-integration/README.md#cloud-integration-configurations).
-
-Q: Do I need to configure the cloud integration on the secondary clusters?\
-A: No, only if you are planning on viewing the UI on the secondary. This is because the cloud reconciliation process happens after the data is shipped to the Thanos store.
 
 Q: What is the difference between `rebuild` and `repair` commands?\
 A: `rebuild` is a legacy command and `repair` should be used instead, as it builds on top of the existing ETL instead of wiping it completely. (Use `repair` command when possible.)
@@ -153,3 +147,6 @@ A. To receive access to these features, you need to properly configure Workload 
 
 Q: How can I configure node-exporter to use an internal cluster IP instead of the node network?\
 A: Set the following Helm value: `prometheus.nodeExporter.hostNetwork=false`.
+
+Q: How cna I configure my displayed currency type?/
+A: Kubecost supports multiple different currency types for display purposes, but does not perform direct currency conversion. This must be configured via your *values.yaml* with the flag `kubecostProductConfigs.currencyCode`.


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

Removes telling users they can configure currency in UI, provides info on Helm flag.


