### PR TITLE
:memo: fix broken url

### DIFF
--- a/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integration-using-irsa.md
+++ b/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integration-using-irsa.md
@@ -28,7 +28,7 @@ Detail for multiple cloud provider setups is [here](/install-and-configure/insta
 
 ### Step 1: Download configuration files
 
-To begin, download the recommended configuration template files from our [poc-common-config repo](https://github.com/kubecost/poc-common-configurations/tree/main/aws-attach-roles). You will need the following files from this folder:
+To begin, download the recommended configuration template files from our [poc-common-config repo](https://github.com/kubecost/poc-common-configurations/tree/main/aws). You will need the following files from this folder:
 
 * _cloud-integration.json_
 * _iam-payer-account-cur-athena-glue-s3-access.json_


### PR DESCRIPTION
## Related issue #

This target url does not exist anymore.


## Proposed Changes

This pull request includes a minor change to the `aws-cloud-integration-using-irsa.md` file. The change updates the URL for the configuration template files in the `poc-common-config` repository. The updated URL now points to the `aws` folder instead of the `aws-attach-roles` folder which does not seems to exist anymore.




