### PR TITLE
Corrected kubeCostAggregator to kubecostAggregator (value name is case sensitive)

### DIFF
--- a/install-and-configure/install/multi-cluster/federated-etl/federated-etl.md
+++ b/install-and-configure/install/multi-cluster/federated-etl/federated-etl.md
@@ -96,7 +96,7 @@ federatedETL:
 If it is not the primary cluster, additionally set the following:
 
 ```yaml
-kubeCostAggregator:
+kubecostAggregator:
   deployMethod: disabled
 ```
 


### PR DESCRIPTION
Our fedETL configuration docs make reference to a kubeCostAggregator setting which is incorrect. It should be kubecostAggregator (lowercase C).


