### PR TITLE
addresses zd-6287, where user was seeing discrepancies between amortized and net amortized costs

### DIFF
--- a/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer/cloud-cost-metrics.md
+++ b/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer/cloud-cost-metrics.md
@@ -110,7 +110,8 @@ The Cost column plus the sum of all credit amounts.
 
 **Amortized Net Cost**
 
-Kubecost uses Net Cost.
+Amortized Net Cost is Cost with all credits and amortized CUD payments
+`amortizedNetCost := cost + creditAmount + cudCreditAmount + flexibleCUDCreditAmount + flexibleCUDNetPayedAmount`
 
 **Invoiced Cost**
 
@@ -118,7 +119,8 @@ Kubecost uses Net Cost.
 
 **Amortized Cost**
 
-Kubecost uses Net Cost.
+Amortized Cost is Cost plus CUD credits and amortized CUD payments
+`amortizedCost := cost + cudCreditAmount + flexibleCUDCreditAmount + flexibleCUDPayedAmount`
 
 </details>
 


### PR DESCRIPTION
## Related issue # 

Closes https://kubecost.zendesk.com/agent/tickets/6287

## Proposed Changes

Needed to update docs to reflect proper definitions for amortized costs and net amortized costs as per opencosts [codebase](https://github.com/opencost/opencost/blob/194ebd1cbb2288002af690b75da5d0cbc26905c8/pkg/cloud/gcp/bigqueryintegration_types.go#L192)



