### PR TITLE
Update docs to reflect RBAC support removal

### DIFF
--- a/install-and-configure/advanced-configuration/user-management-oidc/gluu-server-with-oidc-configuration-guide.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/gluu-server-with-oidc-configuration-guide.md
@@ -1,4 +1,7 @@
 # Gluu Server with OIDC Configuration Guide
+{% hint style="info" %}
+OIDC is only officially supported on Kubecost Enterprise plans. At this time OIDC does not support RBAC.
+{% endhint %}
 
 Gluu is an open-source Identity and Access Management (IAM) platform that can be used to authenticate and authorize users for applications and services. It can be configured to use the OpenID Connect (OIDC) protocol, which is an authentication layer built on top of OAuth 2.0 that allows applications to verify the identity of users and obtain basic profile information about them.
 

--- a/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/microsoft-entra-id-oidc-integration-for-kubecost.md
@@ -1,10 +1,10 @@
 # Microsoft Entra ID OIDC Integration for Kubecost
 
 {% hint style="info" %}
-OIDC is only officially supported on Kubecost Enterprise plans.
+OIDC is only officially supported on Kubecost Enterprise plans. At this time OIDC does not support RBAC.
 {% endhint %}
 
-This guide will take you through configuring OIDC for Kubecost using a Microsoft Entra ID (formerly Azure AD) integration for SSO and RBAC.
+This guide will take you through configuring OIDC for Kubecost using a Microsoft Entra ID (formerly Azure AD) integration for SSO.
 
 ## Prerequisites
 
@@ -52,51 +52,6 @@ If you are using one Entra ID app to authenticate multiple Kubecost endpoints, y
 
 ```
   authURL: "https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize?client_id={YOUR_CLIENT_ID}&response_type=code&scope=openid&nonce=123456&redirect_uri=https%3A%2F%2F{YOUR_KUBECOST_DOMAIN}/model/oidc/authorize"
-```
-
-### Step 3 (optional): Configuring RBAC
-
-First, you need to configure an admin role for your app. For more information on this step, see [Microsoft's documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-app-roles-in-apps).
-
-1. Return to the Overview page for the application you created in Step 1.
-2. Select _App roles_ > _Create app role_. Provide the following values:
-  * Display name: _admin_
-  * Allowed member types: _Users/Groups_
-  * Value: _admin_
-  * Description: _Admins have read/write permissions via the Kubecost frontend_ (or provide a custom description as needed)
-  * Do you want to enable this app role?: Select the checkbox
-3. Select _Apply_.
-
-Then, you need to attach the role you just created to users and groups.
-
-1. In the Azure AD left navigation, select _Applications_ > _Enterprise applications_. Select the application you created in Step 1.
-2. Select _Users & groups_.
-3. Select _Add user/group_. Select the desired group. Select the _admin_ role you created, or another relevant role. Then, select _Assign_ to finalize changes.
-4. Update your existing _values.yaml_ with this template:
-
-```
-oidc:
-  enabled: true
-  # THIS IS REQUIRED FOR AZURE. Azure communicates roles via the id_token instead of the access_token.
-  useIDToken: true
-  rbac:
-    enabled: true
-    groups:
-      - name: admin
-        # If admin is disabled, all authenticated users will be able to make configuration changes to the kubecost frontend
-        enabled: true
-        # SET THIS EXACT VALUE FOR ENTRA ID. This is the string Entra ID uses in its OIDC tokens.
-        claimName: "roles"
-        # These strings need to exactly match with the app roles created in Entra ID
-        claimValues:
-          - "admins"
-          - "superusers"
-      - name: readonly
-        # If readonly is disabled, all authenticated users will default to readonly
-        enabled: true
-        claimName: "roles"
-        claimValues:
-          - "readonly"
 ```
 
 ## Troubleshooting

--- a/install-and-configure/advanced-configuration/user-management-oidc/user-management-oidc-keycloak.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/user-management-oidc-keycloak.md
@@ -1,7 +1,7 @@
 # Configure Keycloak Identity Provider for Kubecost
 
 {% hint style="info" %}
-OIDC is only officially supported on Kubecost Enterprise plans.
+OIDC is only officially supported on Kubecost Enterprise plans. At this time OIDC does not support RBAC.
 {% endhint %}
 
 1. Create a new [Keycloak Realm](https://www.keycloak.org/getting-started/getting-started-kube#\_create\_a\_realm).

--- a/install-and-configure/advanced-configuration/user-management-oidc/user-management-oidc.md
+++ b/install-and-configure/advanced-configuration/user-management-oidc/user-management-oidc.md
@@ -1,7 +1,7 @@
 # User Management (SSO/OIDC)
 
 {% hint style="info" %}
-OIDC is only officially supported on Kubecost Enterprise plans.
+OIDC is only officially supported on Kubecost Enterprise plans. At this time OIDC does not support RBAC.
 {% endhint %}
 
 ## Overview of features
@@ -21,20 +21,6 @@ oidc:
   loginRedirectURL: "http://my.kubecost.url/model/oidc/authorize"
   discoveryURL: "https://my.auth.server/.well-known/openid-configuration"
   skipOnlineTokenValidation: false # Set to 'true' to skip online token validation and attempt to locally validate JWT claims
-  rbac:
-    enabled: false
-    groups:
-      - name: admin
-        enabled: false
-        claimName: "roles"
-        claimValues:
-          - "admin"
-          - "superusers"
-      - name: readonly
-        enabled: false
-        claimName:  "roles"
-        claimValues:
-          - "readonly"
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
## Related Issue

For context, see the discussion here: [Slack link](https://kubecost.slack.com/archives/CLFV60Y90/p1715236093906589).

**TL;DR:** OIDC rbac support has been dropped in version 2.X, so the documentation needs to be updated accordingly.

## Proposed Changes

- Updated the information sections to indicate that RBAC is not supported with OIDC.
- Removed sections that provided RBAC configuration examples for OIDC to avoid any confusion.



