### PR TITLE
Update container-request-right-sizing-recommendations.md to remove 'beta' mention

### DIFF
--- a/using-kubecost/navigating-the-kubecost-ui/savings/container-request-right-sizing-recommendations.md
+++ b/using-kubecost/navigating-the-kubecost-ui/savings/container-request-right-sizing-recommendations.md
@@ -1,9 +1,5 @@
 # Container Request Right-Sizing Recommendations
 
-{% hint style="warning" %}
-This feature is in beta. Please read the documentation carefully.
-{% endhint %}
-
 Kubecost can automatically implement its [recommendations](/apis/savings-apis/api-request-right-sizing-v2.md) for container [resource requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) if you have the [Cluster Controller](/install-and-configure/advanced-configuration/controller/cluster-controller.md) component enabled. Using container request right-sizing (RRS) allows you to instantly optimize resource allocation across your entire cluster. You can easily eliminate resource over-allocation in your cluster, which paves the way for vast savings via cluster right-sizing and other optimizations.
 
 ![Container Request Right-Sizing Recommendations](/images/crss.png)


### PR DESCRIPTION
container right sizing page is NOT a beta feature

## Related issue #

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->



## Proposed Changes

<!--
Describe the changes made in this PR.
-->



