### PR TITLE
update GCP cloud integration config; fix contact links

### DIFF
--- a/.github/workflows/checks-links.yaml
+++ b/.github/workflows/checks-links.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fail: true
           debug: false
-          args: --verbose --no-progress --base . -E './**/*.md' './**/*.html'
+          args: --verbose --include-fragments --no-progress --base . -E './**/*.md' './**/*.html'
 
       # - name: Create Issue From File
       #   if: steps.lychee.outputs.exit_code != 0

--- a/.github/workflows/checks-links.yaml
+++ b/.github/workflows/checks-links.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fail: true
           debug: false
-          args: --verbose --include-fragments --no-progress --base . -E './**/*.md' './**/*.html'
+          args: --verbose --no-progress --base . -E './**/*.md' './**/*.html'
 
       # - name: Create Issue From File
       #   if: steps.lychee.outputs.exit_code != 0

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -187,6 +187,6 @@
 
 ## Other Resources
 
-* [Contact Us](contactus.md)
+* [Contact Us](CONTACT.md)
 * [Kubecost Blog](https://blog.kubecost.com/)
 * [Kubecost Release Notes](https://github.com/kubecost/cost-analyzer-helm-chart/releases)

--- a/install-and-configure/install/cloud-integration/gcp-out-of-cluster/README.md
+++ b/install-and-configure/install/cloud-integration/gcp-out-of-cluster/README.md
@@ -83,13 +83,34 @@ You're almost done. Now it's time to configure Kubecost to finalize your connect
 
 ### Option 4.1: Configuring using values.yaml (recommended)
 
-It is recommended to provide the GCP details in your [_values.yaml_](https://github.com/kubecost/cost-analyzer-helm-chart/blob/c10e9475b51612d36da8f04618174a98cc62f8fd/cost-analyzer/values.yaml#L572-L574) to ensure they are retained during an upgrade or redeploy. First, set the following configs:
+It is recommended to provide the GCP details in your Helm values file. The necessary values may be provided in one of two ways. In the first method, you define the values in-line to your values file. The second method, for users who wish to store the values separately, you pre-create a Kubernetes Secret with the same contents and then reference that Secret in your values file. An example of the in-line method is shown below.
 
 ```yaml
 kubecostProductConfigs:
-  projectID: "$PROJECT_ID"
-  bigQueryBillingDataDataset: "YOUR_DATASET.YOUR_TABLE_NAME"
+  cloudIntegrationJSON: |-
+    {
+      "gcp": [
+        {
+          "projectID": "my-project-id",
+          "billingDataDataset": "detailedbilling.my-billing-dataset",
+          "key": {
+            "type": "service_account",
+            "project_id": "my-project-id",
+            "private_key_id": "my-private-key-id",
+            "private_key": "my-pem-encoded-private-key",
+            "client_email": "my-service-account-name@my-project-id.iam.gserviceaccount.com",
+            "client_id": "my-client-id",
+            "auth_uri": "auth-uri",
+            "token_uri": "token-uri",
+            "auth_provider_x509_cert_url": "my-x509-provider-cert",
+            "client_x509_cert_url": "my-x509-cert-url"
+          }
+        }
+      ]
+    }
 ```
+
+When choosing to pre-create the Secret instead and reference it in the values file, follow the directions provided in the [Helm values file comments](https://github.com/kubecost/cost-analyzer-helm-chart/blob/v2.3/cost-analyzer/values.yaml#L3327-L3330).
 
 If you've connected using Workload Identity Federation, add these configs:
 

--- a/install-and-configure/install/environment.md
+++ b/install-and-configure/install/environment.md
@@ -27,4 +27,4 @@ Kubecost requires a Kubernetes cluster to be deployed.
   * All regions supported, as shown in [opencost/pkg/cloud/azureprovider.go](https://github.com/opencost/opencost/blob/0c2f063052723a65ca62a4c75be23392806b6fac/pkg/cloud/azureprovider.go#L82)
   * x86
 
-**This list is certainly not exhaustive!** This is simply a list of observations as to where our users run Kubecost based on their questions and feedback. Please [contact us](/contactus.md) with any questions!
+**This list is certainly not exhaustive!** This is simply a list of observations as to where our users run Kubecost based on their questions and feedback. Please [contact us](/CONTACT.md) with any questions!

--- a/install-and-configure/install/multi-cluster/federated-etl/thanos-migration-guide.md
+++ b/install-and-configure/install/multi-cluster/federated-etl/thanos-migration-guide.md
@@ -95,7 +95,7 @@ Enabling ETL-Utils will create the directories `/federated/CLUSTER_ID` for every
 
 Enabling [Aggregator](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md) will begin processing the ETL data from the `/federated` directory. The aggregator will then serve all Kubecost queries. Be sure to look at the [Aggregator Optimizations Doc](/install-and-configure/install/multi-cluster/federated-etl/aggregator.md) if Kubecost is ingesting data for ~20,000+ containers. It is difficult to recommend the amount of resources needed due to the uniqueness of each environment and several other variables.
 
-The `federatedStorageConfigSecret`, `etlBucketConfigSecret`, and `thanosSourceBucketSecret` *MUST* all point to the same bucket. Otherwise the data migration will not suceed. Additionally, the cloud-integration *MUST* be configured and referenced following [this method](/install-and-configure/install/cloud-integration/multi-cloud#step-2-create-cloud-integration-secret) or the cloud integration will fail.
+The `federatedStorageConfigSecret`, `etlBucketConfigSecret`, and `thanosSourceBucketSecret` *MUST* all point to the same bucket. Otherwise the data migration will not suceed. Additionally, the cloud-integration *MUST* be configured and referenced following [this method](/install-and-configure/install/cloud-integration/multi-cloud.md#step-2-create-cloud-integration-secret) or the cloud integration will fail.
 
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Related issue #

Fixes #1061
Also fixes contact links being broken I introduced in #1059 

## Proposed Changes

Fixes/updates the guidance in the GCP cloud integration section to list the current 2.x values format. Fixes a broken link according to the link checker.

