### PR TITLE
fix typo in datadog instructions

### DIFF
--- a/integrations/integrating-kubecost-with-datadog.md
+++ b/integrations/integrating-kubecost-with-datadog.md
@@ -28,7 +28,7 @@ Finally, install the Datadog agent with your API key using the following command
 ```sh
 helm repo add datadog https://helm.datadoghq.com
 helm upgrade -i datadog-agent datadog/datadog \
---set --set datadog.site='us5.datadoghq.com' \
+--set datadog.site='us5.datadoghq.com' \
 --set datadog.apiKey=$<DATADOG_KEY_ID> \
 --set datadog.prometheusScrape.enabled=‘true’ \
 --set datadog.prometheusScrape.serviceEndpoints=‘true’


### PR DESCRIPTION
double '--set' in config

## Related Issue

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

## Proposed Changes

<!--
Describe the changes made in this PR.
-->

