### PR TITLE
Fix three errors in the Alibaba installation documentation

### DIFF
--- a/install-and-configure/install/provider-installations/alibaba-install.md
+++ b/install-and-configure/install/provider-installations/alibaba-install.md
@@ -24,7 +24,7 @@ The `alibaba-service-key` can be created using the following command:
 
 {% code overflow="wrap" %}
 ```
-kubectl create secret generic alibaba-service-key -n kubecost –from-file=./example_path
+kubectl create secret generic alibaba-service-key -n kubecost –from-file=your_path/service-key.json
 ```
 {% endcode %}
 
@@ -32,12 +32,13 @@ Your path needs a file having Alibaba Cloud secrets. Alibaba secrets can be pass
 
 ```
 {
-     "alibaba_access_key_id": “XXX”
-     "alibaba_secret_access_key": “XXX"
+     "alibaba_access_key_id": "XXX",
+     "alibaba_secret_access_key": "XX"
 }
 ```
 
 These two can be generated in the Alibaba Cloud portal. Hover over your user account icon, then select _AccessKey Management_. A new window opens. Select _Create AccessKey_ to generate a unique access token that will be used for all activities related to Kubecost.
+In the access key's policy, add the DescribePrice permission to get accurate pricing information.
 
 ## Alibaba Cloud integration
 

--- a/install-and-configure/install/provider-installations/alibaba-install.md
+++ b/install-and-configure/install/provider-installations/alibaba-install.md
@@ -38,6 +38,7 @@ Your path needs a file having Alibaba Cloud secrets. Alibaba secrets can be pass
 ```
 
 These two can be generated in the Alibaba Cloud portal. Hover over your user account icon, then select _AccessKey Management_. A new window opens. Select _Create AccessKey_ to generate a unique access token that will be used for all activities related to Kubecost.
+
 In the access key's policy, add the DescribePrice permission to get accurate pricing information.
 
 ## Alibaba Cloud integration


### PR DESCRIPTION
1. The key file name is fixed: "service-key.json"
2. The key JSON format is incorrect
3. It does not specify the required permissions for the key pair, and has added the necessary permission description.

## Related Issue

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

## Proposed Changes

<!--
Describe the changes made in this PR.
-->

