### PR TITLE
FedETL Migration Guide does not require `DB_BUCKET_REFRESH_INTERVAL`

### DIFF
--- a/install-and-configure/install/multi-cluster/federated-etl/federated-etl-migration-guide.md
+++ b/install-and-configure/install/multi-cluster/federated-etl/federated-etl-migration-guide.md
@@ -110,9 +110,6 @@ Add the following values to your primary cluster Helm values:
 kubecostAggregator:
   replicas: 1
   deployMethod: statefulset
-  extraEnv:
-    - name: DB_BUCKET_REFRESH_INTERVAL
-      value: 2h
 ```
 See this [example .yaml](https://github.com/kubecost/poc-common-configurations/blob/main/etl-federation-aggregator/primary-aggregator.yaml#L1-L14) for what your primary cluster configuration should look like.
 


### PR DESCRIPTION
## Related Issue

N/A

## Proposed Changes

- As titled. As of v2.3 this is no longer an environment variable that can be tuned.
