### PR TITLE
Fix iam policy file path

### DIFF
--- a/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integration-using-irsa.md
+++ b/install-and-configure/install/cloud-integration/aws-cloud-integrations/aws-cloud-integration-using-irsa.md
@@ -39,7 +39,7 @@ To begin, download the recommended configuration template files from our [poc-co
 * _iam-payer-account-trust-primary-account.json_
 * _iam-access-cur-in-payer-account.json_
 
-The bottom three files are found in [/aws/iam-policies-cur](https://github.com/kubecost/poc-common-configurations/tree/main/aws/iam-policies/cur).
+The bottom three files are found in [/aws/iam-policies/cur](https://github.com/kubecost/poc-common-configurations/tree/main/aws/iam-policies/cur).
 
 Begin by opening *cloud_integration.json*, which should look like this:
 


### PR DESCRIPTION
## Related Issue

<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

## Proposed Changes

<!--
Describe the changes made in this PR.
-->

Corrected the path for IAM policy files in the documentation from /aws/iam-policies-cur to /aws/iam-policies/cur to ensure accurate referencing.


