### PR TITLE
Remove incorrect info about Prometheus data retention

### DIFF
--- a/install-and-configure/advanced-configuration/custom-prom/custom-prom.md
+++ b/install-and-configure/advanced-configuration/custom-prom/custom-prom.md
@@ -116,14 +116,6 @@ kubecostModel:
   promClusterIDLabel: cluster_id
 ```
 
-### Data retention
-
-By default, metric retention is 91 days, however the retention of data can be further increased with a configurable value for a property `etlDailyStoreDurationDays`. You can find this value in Kubecost's [Helm chart](https://github.com/kubecost/cost-analyzer-helm-chart/blob/9f3d7974247bfd3910fbf69d0d4bd66f1335201a/cost-analyzer/values.yaml#L340).
-
-{% hint style="warning" %}
-Increasing the default `etlDailyStorageDurationDays` value will naturally result in greater memory usage. At higher values, this can cause errors when trying to display this information in the Kubecost UI. You can remedy this by increasing the [Step size](/using-kubecost/navigating-the-kubecost-ui/cost-allocation/README.md#step-size) when using the Allocations dashboard.
-{% endhint %}
-
 ## Troubleshooting
 
 The Diagnostics page (_Settings > View Full Diagnostics_) provides diagnostic info on your integration. Scroll down to Prometheus Status to verify that your configuration is successful.


### PR DESCRIPTION
## Related Issue

N/A

## Proposed Changes

Remove section of docs about "Prometheus Data Retention". The configs proposed here, have moreso to do with Kubecost data retention as opposed to Prometheus metric retention. Delete the section.

If people are interested in adjusting Prometheus's metric retention, it is well documented already in the Helm Chart: https://github.com/kubecost/cost-analyzer-helm-chart/blob/e98d38e7e99a329719e6c814560b71ee83cc7b82/cost-analyzer/values.yaml#L1340-L1365

