### PR TITLE
Adds back Hitach and Storj storage configurations

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
       * [Azure Long-Term Storage](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-azure.md)
       * [GCP Long-Term Storage](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-gcp.md)
       * [Hitachi Content Platform (HCP) Storage Configuration](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-hitachi.md)
+      * [Storj Storage Configuration](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-storj.md)
     * [Secondary Clusters Guide](install-and-configure/install/multi-cluster/secondary-clusters.md)
     * [Multi-Cluster Diagnostics](install-and-configure/install/multi-cluster/multi-cluster-diagnostics.md)
 * [Additional Configuration](install-and-configure/advanced-configuration/README.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -45,6 +45,7 @@
       * [AWS Multi-Cluster Storage Configuration](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-aws.md)
       * [Azure Long-Term Storage](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-azure.md)
       * [GCP Long-Term Storage](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-gcp.md)
+      * [Hitachi Content Platform (HCP) Storage Configuration](install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-hitachi.md)
     * [Secondary Clusters Guide](install-and-configure/install/multi-cluster/secondary-clusters.md)
     * [Multi-Cluster Diagnostics](install-and-configure/install/multi-cluster/multi-cluster-diagnostics.md)
 * [Additional Configuration](install-and-configure/advanced-configuration/README.md)

--- a/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-azure.md
+++ b/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-azure.md
@@ -4,7 +4,7 @@
 Usage of a Federated Storage Bucket is only supported for Kubecost Enterprise plans.
 {% endhint %}
 
-To use Azure Storage as Thanos object store, you need to precreate a storage account from Azure portal or using Azure CLI. Follow the instructions from the [Azure Storage Documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account).
+To use Azure Storage as an ETL object store, you need to pre-create a storage account from Azure the portal or using the Azure CLI. Follow the instructions from the [Azure Storage Documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account).
 
 Now create a .YAML file named `federated-store.yaml` with the following format:
 

--- a/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-hitachi.md
+++ b/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-hitachi.md
@@ -1,0 +1,30 @@
+# Hitachi Content Platform (HCP) Multi-Cluster Storage Configuration
+
+{% hint style="info" %}
+Usage of a Federated Storage Bucket is only supported for Kubecost Enterprise plans.
+{% endhint %}
+
+Because HCP is [S3 compatible](https://knowledge.hitachivantara.com/Documents/Storage/HCP\_for\_Cloud\_Scale/1.0.0/Adminstering\_HCP\_for\_cloud\_scale/Getting\_started/02\_Support\_for\_Amazon\_S3\_API), it can be used as a drop-in replacement for S3.
+
+To obtain the necessary S3 User Credentials, see [Hitachi's documentation](https://knowledge.hitachivantara.com/Documents/Storage/HCP\_for\_Cloud\_Scale/1.0.0/Adminstering\_HCP\_for\_cloud\_scale/Object\_storage\_management/01\_S3\_User\_Credentials#GUID-6DA3811F-FBC5-4848-B47D-B2297F0902B7).
+
+Now create a .YAML file named `federated-store.yaml` with the following format:
+
+```yaml
+type: S3
+config:
+  bucket: "folder name" # Folder created in the HCP endpoint bucket, not the pre-existing bucket name.
+  endpoint: "your.hcp-endpoint.com"
+  access_key: "<HITACHI_ACCESS_KEY>"
+  secret_key: "<HITACHI_SECRET_KEY>"
+  insecure: false
+  signature_version2: false
+  http_config:
+    idle_conn_timeout: 90s
+    response_header_timeout: 2m
+    insecure_skip_verify: false
+  trace:
+    enable: true
+  part_size: 134217728
+prefix: ""  # Optional. Specify a path within the bucket (e.g. "kubecost/etl").
+```

--- a/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-storj.md
+++ b/install-and-configure/install/multi-cluster/long-term-storage-configuration/long-term-storage-storj.md
@@ -1,0 +1,28 @@
+# Storj Multi-Cluster Storage Configuration
+
+{% hint style="info" %}
+Usage of a Federated Storage Bucket is only supported for Kubecost Enterprise plans.
+{% endhint %}
+
+Because Storj is [S3 compatible](https://docs.storj.io/dcs/api-reference/s3-compatible-gateway/), it can be used as a drop-in replacement for S3.
+
+After an S3 Compatible Access Grant has been created, create a .YAML file named `federated-store.yaml` with the following format:
+
+```yaml
+type: S3
+config:
+  bucket: "my-bucket"
+  endpoint: "gateway.storjshare.io"
+  access_key: "<STORJ_ACCESS_KEY>"
+  secret_key: "<STORJ_SECRET_KEY>"
+  insecure: false
+  signature_version2: false
+  http_config:
+    idle_conn_timeout: 90s
+    response_header_timeout: 2m
+    insecure_skip_verify: false
+  trace:
+    enable: true
+  part_size: 134217728
+prefix: ""  # Optional. Specify a path within the bucket (e.g. "kubecost/etl").
+```


### PR DESCRIPTION
## Proposed Changes

Adds back the lost storage configuration when we deprecated the ETL Backup docs from the 2.x branch.
https://github.com/kubecost/docs/blob/ce23be12ba50c6e7b9089956324135f42b5beb7f/install-and-configure/install/etl-backup/etl-backup.md?plain=1#L131-L191
