### PR TITLE
correct log level docs

### DIFF
--- a/troubleshooting/troubleshoot-install.md
+++ b/troubleshooting/troubleshoot-install.md
@@ -50,9 +50,13 @@ kubectl logs deployment/kubecost-cost-analyzer -c cost-model
 
 Alternatively, Lens is a great tool for diagnosing many issues in a single view. See our blog post on [using Lens with Kubecost](https://blog.kubecost.com/blog/lens-kubecost-extension/) to learn more.
 
-## Configuring log levels
+## Configuring Log Levels
 
-The log output can be adjusted while deploying through Helm by using the `LOG_LEVEL` and/or `LOG_FORMAT` environment variables. These variables include:
+You can adjust the log output while deploying through Helm by using the `logLevel` property and/or the `LOG_FORMAT` environment variable.
+
+### Log Level Values
+
+The `logLevel` property accepts the following values:
 
 * `trace`
 * `debug`
@@ -65,15 +69,23 @@ For example, to set the log level to `debug`, add the following flag to the Helm
 
 {% code overflow="wrap" %}
 ```bash
---set 'kubecostModel.extraEnv[0].name=LOG_LEVEL,kubecostModel.extraEnv[0].value=debug'
+--set 'kubecostModel.logLevel=debug'
 ```
 {% endcode %}
 
-You can set `LOG_LEVEL` to generate two different outputs.
+### Log Format
 
-Setting it to `JSON` will generate a structured logging output: `{"level":"info","time":"2006-01-02T15:04:05.999999999Z07:00","message":"Starting cost-model (git commit \"1.91.0-rc.0\")"}`
+You can set the `LOG_FORMAT` environment variable to generate different types of log outputs:
 
-Setting `LOG_LEVEL` to `pretty` will generate a nice human-readable output: `2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")`
+* Setting `LOG_FORMAT` to `JSON` will generate structured logging output:
+  ```json
+  {"level":"info","time":"2006-01-02T15:04:05.999999999Z07:00","message":"Starting cost-model (git commit \"1.91.0-rc.0\")"}
+  ```
+
+* Setting `LOG_FORMAT` to `pretty` will generate a human-readable output:
+  ```
+  2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")
+  ```
 
 ### Temporarily set log level
 

--- a/troubleshooting/troubleshoot-install.md
+++ b/troubleshooting/troubleshoot-install.md
@@ -54,9 +54,8 @@ Alternatively, Lens is a great tool for diagnosing many issues in a single view.
 
 You can adjust the log output while deploying through Helm by using the `logLevel` property and/or the `LOG_FORMAT` environment variable.
 
-### Log Level Values
-
-The `logLevel` property accepts the following values:
+### Adjusting Log Level
+Adjusting the log level increases or decreases the level of verbosity written to the logs. The `logLevel` property accepts the following values:
 
 * `trace`
 * `debug`
@@ -73,19 +72,14 @@ For example, to set the log level to `debug`, add the following flag to the Helm
 ```
 {% endcode %}
 
-### Log Format
+### Adjusting Log Format
 
-You can set the `LOG_FORMAT` environment variable to generate different types of log outputs:
+Adjusting the log format changes the format in which the logs are output making it easier for log aggregators to parse and display logged messages. The `LOG_FORMAT` environment variable accepts the values `JSON`, for a structured output, and `pretty` for a nice, human-readable output.
 
-* Setting `LOG_FORMAT` to `JSON` will generate structured logging output:
-  ```json
-  {"level":"info","time":"2006-01-02T15:04:05.999999999Z07:00","message":"Starting cost-model (git commit \"1.91.0-rc.0\")"}
-  ```
-
-* Setting `LOG_FORMAT` to `pretty` will generate a human-readable output:
-  ```
-  2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")
-  ```
+| Value  | Output                                                                                                                     |
+|--------|----------------------------------------------------------------------------------------------------------------------------|
+| `JSON`   | `{"level":"info","time":"2006-01-02T15:04:05.999999999Z07:00","message":"Starting cost-model (git commit \"1.91.0-rc.0\")"}` |
+| `pretty` | `2006-01-02T15:04:05.999999999Z07:00 INF Starting cost-model (git commit "1.91.0-rc.0")`                                     |
 
 ### Temporarily set log level
 


### PR DESCRIPTION
## Related PR
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3717
<!--
Please link the GitHub issue, if one exists, to this pull request by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) such as "Closes #1234" for features/enhancements and "Fixes #1234" for bugs.
-->

## Proposed Changes
Update the docs for setting log level in helm values to use `logLevel` property instead of setting it in extra Env
<!--
Describe the changes made in this PR.
-->

