### PR TITLE
Ignore jwt.io on link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,4 @@ https://knowledge.hitachivantara.com*
 http://sso.hitachivantara.com*
 https://www.kubecost.com/pricing/*
 https://www.gnu.org/*
+https://jwt.io/*


### PR DESCRIPTION
## Related Issue

N/A

## Proposed Changes

This link caused failing CI checks. It's likely that https://jwt.io began blocking non-human requests with HTTP 500s.

