### PR TITLE
Remove default for kubecostAggregator.dbReadThreads` thread limit on read database

### DIFF
--- a/install-and-configure/advanced-configuration/resource-consumption.md
+++ b/install-and-configure/advanced-configuration/resource-consumption.md
@@ -81,6 +81,8 @@ kubecostAggregator:
   dbConcurrentIngestionCount: 1
 ```
 
+Note that by default, `dbReadThreads` is set to `0` which means that the number of threads that can be used by the read database is bound by the number of cores on the host node.
+
 **Set rough memory limits.** By default these are set to `0GB` which means no limit. Once a baseline memory usage is established, it can be helpful to set these limits such that `dbMemoryLimit + dbWriteMemoryLimit <= memoryAvailableToAggregatorPod`.
 
 {% hint style="warning" %}

--- a/install-and-configure/install/multi-cluster/federated-etl/aggregator.md
+++ b/install-and-configure/install/multi-cluster/federated-etl/aggregator.md
@@ -83,10 +83,10 @@ kubecostAggregator:
   etlDailyStoreDurationDays: 91
 
   # How many threads the read database is configured with (i.e. Kubecost API /
-  # UI queries). If increasing this value, it is recommended to increase the
-  # aggregator's memory requests & limits.
-  # default: 1
-  dbReadThreads: 1
+  # UI queries). If value is 0, the number of threads is bound by the
+  # number of cores
+  # default: 0 is no limit
+  dbReadThreads: 0
 
   # How many threads the write database is configured with (i.e. ingestion of
   # new data from S3). If increasing this value, it is recommended to increase


### PR DESCRIPTION
## Related Issue
https://github.com/kubecost/cost-analyzer-helm-chart/pull/3845

## Proposed Changes

The helm chart PR above modifies the `kubecostAggregator.dbReadThreads` default value. This PR updates the public documentation to reflect this change.

