### PR TITLE
[KCM-3737] Collections: Recommend against using idle 'share by cluster'

### DIFF
--- a/using-kubecost/navigating-the-kubecost-ui/collections.md
+++ b/using-kubecost/navigating-the-kubecost-ui/collections.md
@@ -50,7 +50,8 @@ Selecting the three vertical dots in the top right of the collection tile will p
 
 Costs in the Kubernetes domain have a corresponding idle component. For any Kubernetes costs part of a collection, the idle cost can be optionally configured to be _included_ in the total cost displayed. This can be done from the Settings page under Idle in Collections.
 
-The idle cost can be shared by cluster or by node. We do not recommend sharing idle by cluster as that may lead to cost inconsistencies when deduplicating the Kubernetes costs against the cloud costs for the same resource. By default, idle costs are hidden. 
+The idle cost can be shared by cluster or by node. We do not recommend sharing idle costs by cluster, as that may lead to cost inconsistencies: when idle is shared by cluster, Kubernetes workloads may incur idle costs from other nodes; however, in Collections, the costs of the Kubernetes workloads are deduplicated against the cost of the (single) node they are running on, as detected in the Cloud domain. By default, idle costs are hidden. 
+
 
 If enabled, the 'Idle' column on the _Costs in Collection_ view will display the corresponding idle cost under each item.
 

--- a/using-kubecost/navigating-the-kubecost-ui/collections.md
+++ b/using-kubecost/navigating-the-kubecost-ui/collections.md
@@ -48,7 +48,9 @@ Selecting the three vertical dots in the top right of the collection tile will p
 
 ## Viewing idle costs
 
-Costs in the Kubernetes domain have a corresponding idle component. For any Kubernetes costs part of a Collection, the idle cost can be optionally configured to be _included_ in the total cost displayed. The idle cost can be shared by cluster or by node. This can be configured on the Settings page under Idle in Collections. By default, idle costs are hidden. 
+Costs in the Kubernetes domain have a corresponding idle component. For any Kubernetes costs part of a collection, the idle cost can be optionally configured to be _included_ in the total cost displayed. This can be done from the Settings page under Idle in Collections.
+
+The idle cost can be shared by cluster or by node. We do not recommend sharing idle by cluster as that may lead to cost inconsistencies when deduplicating the Kubernetes costs against the cloud costs for the same resource. By default, idle costs are hidden. 
 
 If enabled, the 'Idle' column on the _Costs in Collection_ view will display the corresponding idle cost under each item.
 

--- a/using-kubecost/navigating-the-kubecost-ui/collections.md
+++ b/using-kubecost/navigating-the-kubecost-ui/collections.md
@@ -50,10 +50,9 @@ Selecting the three vertical dots in the top right of the collection tile will p
 
 Costs in the Kubernetes domain have a corresponding idle component. For any Kubernetes costs part of a collection, the idle cost can be optionally configured to be _included_ in the total cost displayed. This can be done from the Settings page under Idle in Collections.
 
-The idle cost can be shared by cluster or by node. We do not recommend sharing idle costs by cluster, as that may lead to cost inconsistencies: when idle is shared by cluster, Kubernetes workloads may incur idle costs from other nodes; however, in Collections, the costs of the Kubernetes workloads are deduplicated against the cost of the (single) node they are running on, as detected in the Cloud domain. By default, idle costs are hidden. 
+The idle cost can be shared by cluster or by node. We do not recommend sharing idle by cluster as that may lead to cost inconsistencies when deduplicating the Kubernetes costs against the cloud costs for the same resource. To learn more about how costs in Collections are calculated, see this blog post: https://blog.kubecost.com/blog/how-kubecost-collections-works/
 
-
-If enabled, the 'Idle' column on the _Costs in Collection_ view will display the corresponding idle cost under each item.
+By default, idle costs are hidden. If enabled, the 'Idle' column on the _Costs in Collection_ view will display the corresponding idle cost under each item.
 
 To learn more about sharing idle costs, see [here](/using-kubecost/navigating-the-kubecost-ui/cost-allocation/efficiency-idle.md#sharing-idle).
 


### PR DESCRIPTION
## Related Issue
https://apptio.atlassian.net/browse/KCM-3737

## Proposed Changes
Add a note in public docs warning against using idle 'share by cluster' due to risk of potential cost inconsistencies.

**Content to be published via manual migration to IBM docs. This PR is only for review purposes.**

