### PR TITLE
Remove references to ContainerStats pipeline

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -175,7 +175,6 @@
 * [Open Source](architecture/open-source-deps.md)
 * [Kubecost Metrics](architecture/user-metrics.md)
 * [Kube-State-Metrics (KSM) Emission](architecture/ksm-metrics.md)
-* [ContainerStats Pipeline](architecture/containerstats-pipeline.md)
 * [High Availability Mode](architecture/high-availability.md)
 * [GPU Allocation](architecture/gpu-allocation.md)
 * [Kubecost Cluster Roles](architecture/kubecost-cluster-roles.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -175,6 +175,7 @@
 * [Open Source](architecture/open-source-deps.md)
 * [Kubecost Metrics](architecture/user-metrics.md)
 * [Kube-State-Metrics (KSM) Emission](architecture/ksm-metrics.md)
+* [ContainerStats Pipeline](architecture/containerstats-pipeline.md)
 * [High Availability Mode](architecture/high-availability.md)
 * [GPU Allocation](architecture/gpu-allocation.md)
 * [Kubecost Cluster Roles](architecture/kubecost-cluster-roles.md)

--- a/apis/savings-apis/api-request-right-sizing-v2.md
+++ b/apis/savings-apis/api-request-right-sizing-v2.md
@@ -10,7 +10,7 @@ Duration of time over which to query. Accepts multiple different formats of time
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="algorithmCPU" type="string" required="false" %}
-The algorithm to be used to calculate CPU recommendations based on historical CPU usage data. Options are `max` and `quantile`. Max recommendations are based on the maximum-observed usage in `window`. Quantile recommendations are based on a quantile of observed usage in `window` (requires the `qCPU` parameter to set the desired quantile). Defaults to `max`. To use the `quantile` algorithm, the [ContainerStats Pipeline](/architecture/containerstats-pipeline.md) must be enabled (it will be enabled by default).
+The algorithm to be used to calculate CPU recommendations based on historical CPU usage data. Options are `max` and `quantile`. Max recommendations are based on the maximum-observed usage in `window`. Quantile recommendations are based on a quantile of observed usage in `window` (requires the `qCPU` parameter to set the desired quantile). Defaults to `max`.
 {% endswagger-parameter %}
 
 {% swagger-parameter in="query" name="algorithmRAM" type="string" required="false" %}

--- a/architecture/containerstats-pipeline.md
+++ b/architecture/containerstats-pipeline.md
@@ -1,7 +1,7 @@
 # ContainerStats Pipeline
 
 > [!CAUTION]
-> The ContainerStats pipeline is deprecated. This page should no longer be consulted. Kubecost APIs no longer use this pipeline's data.
+> The ContainerStats pipeline is now removed. This page should no longer be consulted. Kubecost APIs no longer use this pipeline's data.
 
 The ContainerStats pipeline builds statistical representations of individual containers' resource usage over time. The pipeline is part of the `cost-model` container.
 

--- a/architecture/containerstats-pipeline.md
+++ b/architecture/containerstats-pipeline.md
@@ -1,5 +1,8 @@
 # ContainerStats Pipeline
 
+> [!CAUTION]
+> The ContainerStats pipeline is deprecated. This page should no longer be consulted. Kubecost APIs no longer use this pipeline's data.
+
 The ContainerStats pipeline builds statistical representations of individual containers' resource usage over time. The pipeline is part of the `cost-model` container.
 
 ## Helm configuration

--- a/install-and-configure/advanced-configuration/resource-consumption.md
+++ b/install-and-configure/advanced-configuration/resource-consumption.md
@@ -14,11 +14,9 @@ kubecostModel:
   etlHourlyStoreDurationHours: 0
 ```
 
-**Disable features which are default-enabled.** Features such as [Container Stats](/architecture/containerstats-pipeline.md) and [Network Monitoring](/using-kubecost/navigating-the-kubecost-ui/network-monitoring.md) are enabled by default. If not using these features, disabling them can reduce Prometheus queries, and also reduce memory consumption of cost-model and Prometheus.
+**Disable features which are default-enabled.** Features such as [Network Monitoring](/using-kubecost/navigating-the-kubecost-ui/network-monitoring.md) are enabled by default. If not using these features, disabling them can reduce Prometheus queries, and also reduce memory consumption of cost-model and Prometheus.
 
 ```yaml
-kubecostModel:
-  containerStatsEnabled: false
 networkCosts:
   config:
     services:

--- a/install-and-configure/install/multi-cluster/federated-etl/thanos-migration-guide.md
+++ b/install-and-configure/install/multi-cluster/federated-etl/thanos-migration-guide.md
@@ -149,7 +149,6 @@ kubecostModel:
   federatedStorageConfigSecret: federated-store
   etlBucketConfigSecret: "" # make sure ETL backups are disabled on secondary clusters
   etl: true
-  containerStatsEnabled: true
   warmCache: false
   warmSavingsCache: false
 ```


### PR DESCRIPTION
## Related Issue

- [KCM-3826](https://apptio.atlassian.net/browse/KCM-3826)
- [KCM-2887](https://apptio.atlassian.net/browse/KCM-2887)
- Documents https://github.com/kubecost/cost-analyzer-helm-chart/pull/3683

## Proposed Changes

Remove references to ContainerStats, as its data is no longer required in the product.



[KCM-3826]: https://apptio.atlassian.net/browse/KCM-3826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KCM-2887]: https://apptio.atlassian.net/browse/KCM-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ